### PR TITLE
Correctly name profiles for shells outside /usr

### DIFF
--- a/tabby-local/src/shells/posix.ts
+++ b/tabby-local/src/shells/posix.ts
@@ -24,7 +24,7 @@ export class POSIXShellsProvider extends ShellProvider {
             .filter(x => x && !x.startsWith('#'))
             .map(x => ({
                 id: slugify(x),
-                name: x.split('/')[2],
+                name: x.split('/').pop(),
                 icon: 'fas fa-terminal',
                 command: x,
                 args: ['-l'],


### PR DESCRIPTION
Shells outside `/usr` get named incorrectly. E.g., if I add `/usr/local/bin/fish` to `/etc/shells`, when Tabby starts up, it think the profile name should be "local".