### PR TITLE
Add description to port forwarding and autofill inputs with the deleted port

### DIFF
--- a/tabby-ssh/src/api/interfaces.ts
+++ b/tabby-ssh/src/api/interfaces.ts
@@ -44,6 +44,7 @@ export interface ForwardedPortConfig {
     port: number
     targetAddress: string
     targetPort: number
+    description: string
 }
 
 export const ALGORITHM_BLACKLIST = [

--- a/tabby-ssh/src/components/sshPortForwardingConfig.component.pug
+++ b/tabby-ssh/src/components/sshPortForwardingConfig.component.pug
@@ -1,14 +1,20 @@
 .list-group.mb-3
     .list-group-item.d-flex.align-items-center(*ngFor='let fw of model')
-        strong(*ngIf='fw.type === PortForwardType.Local') Local
-        strong(*ngIf='fw.type === PortForwardType.Remote') Remote
-        strong(*ngIf='fw.type === PortForwardType.Dynamic') Dynamic
-        .ml-3 {{fw.host}}:{{fw.port}}
-        .ml-2 &rarr;
-        .ml-2(*ngIf='fw.type !== PortForwardType.Dynamic') {{fw.targetAddress}}:{{fw.targetPort}}
-        .ml-2(*ngIf='fw.type === PortForwardType.Dynamic') SOCKS proxy
+        div
+            span {{fw.description}}
+            .ms-2.d-flex.align-items-center
+                strong(*ngIf='fw.type === PortForwardType.Local') Local
+                strong(*ngIf='fw.type === PortForwardType.Remote') Remote
+                strong(*ngIf='fw.type === PortForwardType.Dynamic') Dynamic
+                .ml-3 {{fw.host}}:{{fw.port}}
+                .ml-2 &rarr;
+                .ml-2(*ngIf='fw.type !== PortForwardType.Dynamic') {{fw.targetAddress}}:{{fw.targetPort}}
+                .ml-2(*ngIf='fw.type === PortForwardType.Dynamic') SOCKS proxy
         button.btn.btn-link.hover-reveal.ml-auto((click)='remove(fw)')
             i.fas.fa-trash-alt
+
+.input-group.mb-2
+    input.form-control(type='text', placeholder='Description', [(ngModel)]='newForward.description')
 
 .input-group.mb-2(*ngIf='newForward.type === PortForwardType.Dynamic')
     input.form-control(type='text', [(ngModel)]='newForward.host')

--- a/tabby-ssh/src/components/sshPortForwardingConfig.component.ts
+++ b/tabby-ssh/src/components/sshPortForwardingConfig.component.ts
@@ -41,5 +41,6 @@ export class SSHPortForwardingConfigComponent {
 
     remove (fw: ForwardedPortConfig) {
         this.forwardRemoved.emit(fw)
+        this.newForward = fw
     }
 }

--- a/tabby-ssh/src/components/sshPortForwardingConfig.component.ts
+++ b/tabby-ssh/src/components/sshPortForwardingConfig.component.ts
@@ -26,6 +26,7 @@ export class SSHPortForwardingConfigComponent {
             port: 8000,
             targetAddress: '127.0.0.1',
             targetPort: 80,
+            description: '',
         }
     }
 

--- a/tabby-ssh/src/session/forwards.ts
+++ b/tabby-ssh/src/session/forwards.ts
@@ -9,6 +9,7 @@ export class ForwardedPort implements ForwardedPortConfig {
     port: number
     targetAddress: string
     targetPort: number
+    description: string
 
     private listener: Server|null = null
 


### PR DESCRIPTION
Hi!

I have been using it for a few days and I think it would be great to be able to put descriptions to the port forwardings, or at least for me it would be very useful to remember why port 3593 points to 7234 😛 

I have also made that when a port is deleted, this information remains in the creation form, in case you wanted to edit it or have accidentally deleted it 