### PR TITLE
Fix app not quitting completely on Cmd+Q (Mac)

### DIFF
--- a/app/lib/app.ts
+++ b/app/lib/app.ts
@@ -94,7 +94,7 @@ export class Application {
         }
 
         app.on('window-all-closed', () => {
-            if (this.quitRequested || process.platform !== 'darwin') {
+            if (this.quitRequested) {
                 app.quit()
             }
         })


### PR DESCRIPTION
This change seems to fix #4930 for me locally.
This was initially added in https://github.com/Eugeny/tabby/commit/bcf09c59e35819981945a79d0db6a35333ff11b5 by @Eugeny - is there any specific reason for why you added the check to exclude Macs here?

closes #4930