### PR TITLE
Fix app not quitting completely on Cmd+Q (Mac)

### DIFF
--- a/app/lib/app.ts
+++ b/app/lib/app.ts
@@ -93,6 +93,10 @@ export class Application {
             app.commandLine.appendSwitch(flag[0], flag[1])
         }
 
+        app.on('before-quit', () => {
+            this.quitRequested = true
+        })
+
         app.on('window-all-closed', () => {
             if (this.quitRequested || process.platform !== 'darwin') {
                 app.quit()


### PR DESCRIPTION
This PR sets the `quitRequested` variable to `true` before the application starts closing its windows.
This fixes the issue which prevented Mac from being shut down unless you quit Tabby manually.

related to #5670
closes #4930