### PR TITLE
Fixing fluent not working as expected for Windows 11

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -420,7 +420,7 @@ export class Window {
 
         let moveEndedTimeout: any = null
         const onBoundsChange = () => {
-            if (!this.lastVibrancy?.enabled || !this.disableVibrancyWhileDragging || !this.isFluentVibrancy) {
+            if (!this.lastVibrancy?.enabled || !this.disableVibrancyWhileDragging || this.isFluentVibrancy) {
                 return
             }
             this.setVibrancy(false, undefined, false)

--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -415,12 +415,12 @@ export class Window {
         this.window.webContents.on('new-window', event => event.preventDefault())
 
         ipcMain.on('window-set-disable-vibrancy-while-dragging', (_event, value) => {
-            this.disableVibrancyWhileDragging = value
+            this.disableVibrancyWhileDragging = value && this.configStore.hacks.disableVibrancyWhileDragging
         })
 
         let moveEndedTimeout: any = null
         const onBoundsChange = () => {
-            if (!this.lastVibrancy?.enabled || !this.disableVibrancyWhileDragging || this.isFluentVibrancy) {
+            if (!this.lastVibrancy?.enabled || !this.disableVibrancyWhileDragging || !this.isFluentVibrancy) {
                 return
             }
             this.setVibrancy(false, undefined, false)

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "electron-promise-ipc": "^2.2.4",
     "electron-updater": "^4.6.5",
     "fontmanager-redux": "1.1.0",
-    "glasstron": "0.0.7",
+    "glasstron": "0.1.1",
     "js-yaml": "4.1.0",
     "keytar": "^7.9.0",
     "mz": "^2.7.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1303,12 +1303,12 @@ github-from-package@0.0.0:
   resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-glasstron@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/glasstron/-/glasstron-0.0.7.tgz#d0f3e8344351bbcb89a39323282b4ddb06b03ba0"
-  integrity sha512-zeqfC0E153yBKWHB8ZBA5rT1o1dCCQcPECBryzWLX3uy6VTX3CUcy7kjk/4BlVztEIbpV2plEetpOxSAOe5cqw==
+glasstron@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/glasstron/-/glasstron-0.1.1.tgz#491a2e6f7e7b285c3776c5f7af7aaba2269833b2"
+  integrity sha512-oLEMQM5wwdAQ44NrXD3wjk+b3dsfQG1XtkLn5pCxQNa3ri1AtWvvzpnhFUd88ZTmguHvkY4c3JKzcPSYaJAKKA==
   dependencies:
-    node-addon-api "^3.0.0"
+    node-addon-api "^4.0.0"
     x11 "^2.3.0"
 
 glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
@@ -2277,12 +2277,12 @@ node-addon-api@3.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz"
   integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
 
-node-addon-api@^3.0.0, node-addon-api@^3.0.2, node-addon-api@^3.1.0:
+node-addon-api@^3.0.2, node-addon-api@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz"
   integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
 
-node-addon-api@^4.3.0:
+node-addon-api@^4.0.0, node-addon-api@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==

--- a/tabby-core/src/configDefaults.yaml
+++ b/tabby-core/src/configDefaults.yaml
@@ -38,4 +38,5 @@ enableExperimentalFeatures: false
 pluginBlacklist: []
 hacks:
   disableGPU: false
+  disableVibrancyWhileDragging: false
 language: null

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -315,3 +315,13 @@ h3.mt-4(translate) Hacks
         [(ngModel)]='config.store.hacks.disableGPU',
         (ngModelChange)='config.save(); config.requestRestart()'
     )
+
+.form-line(*ngIf='hostApp.platform === Platform.Windows')
+    .header
+        .title Disable fluent background while dragging
+        .description Fluent background sometimes causes drag lag
+
+    toggle(
+        [(ngModel)]='config.store.hacks.disableVibrancyWhileDragging',
+        (ngModelChange)='config.save(); config.requestRestart()'
+    )


### PR DESCRIPTION
Before the glasstron bump:

https://user-images.githubusercontent.com/2633321/157175135-6763f346-6cfb-420e-bd42-4b289f0b63b0.mp4

After the bump (also not disabling fluent while dragging):

https://user-images.githubusercontent.com/2633321/157175230-e6fce0cc-eb27-4793-8842-a52ae9b076d5.mp4


I need your help here @Eugeny because I don't know the story behind disabling dragging with fluent or if this was also fixed by bump of the glasstron.