### PR TITLE
fix crash on Windows 7

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -182,7 +182,7 @@ export class Window {
                     console.error('Failed to set window blur', error)
                 }
             } else {
-                DwmEnableBlurBehindWindow(this.window, enabled)
+                DwmEnableBlurBehindWindow(this.window.getNativeWindowHandle(), enabled)
             }
         } else if (process.platform === 'linux') {
             this.window.setBackgroundColor(enabled ? '#00000000' : '#131d27')


### PR DESCRIPTION
After debugging I found the crash on win7 is caused by `DwmEnableBlurBehindWindow` in `window.ts`.
`window.ts` pass `this.window` to `windows-blurbehind`, then `windows-blurbehind` pass this object to `node::Buffer::Data`:
https://github.com/Eugeny/windows-blurbehind/blob/30a3dd4f357493d796c1e4770f478bdf6840d4af/src/blurbehind.cc#L7
`node::Buffer::Data` found it's not a `ArrayBufferView` and crash:
https://github.com/nodejs/node/blob/v16.13.0/src/node_buffer.cc#L246

Tabby 1.0.167 uses electron 13.5.1, I don't know why it works. According to electron [docs](https://www.electronjs.org/zh/docs/latest/api/browser-window#wingetnativewindowhandle), here should use `win.getNativeWindowHandle()` to get `Buffer` of window handle.

Fixes #5339, #5465, #5528, #5794