### PR TITLE
Preserve profile groups collapse state.

### DIFF
--- a/tabby-settings/src/components/profilesSettingsTab.component.pug
+++ b/tabby-settings/src/components/profilesSettingsTab.component.pug
@@ -36,7 +36,7 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                 ng-container(*ngFor='let group of profileGroups')
                     ng-container(*ngIf='isGroupVisible(group)')
                         .list-group-item.list-group-item-action.d-flex.align-items-center(
-                            (click)='group.collapsed = !group.collapsed'
+                            (click)='toggleGroupCollapse(group)'
                         )
                             .fa.fa-fw.fa-chevron-right(*ngIf='group.collapsed')
                             .fa.fa-fw.fa-chevron-down(*ngIf='!group.collapsed')

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -143,6 +143,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     refresh (): void {
         this.profiles = this.config.store.profiles
         this.profileGroups = []
+        const profileGroupCollapsed = JSON.parse(window.localStorage.profileGroupCollapsed ?? '{}')
 
         for (const profile of this.profiles) {
             let group = this.profileGroups.find(x => x.name === profile.group)
@@ -151,7 +152,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
                     name: profile.group,
                     profiles: [],
                     editable: true,
-                    collapsed: false,
+                    collapsed: profileGroupCollapsed[profile.group ?? ''] ?? false,
                 }
                 this.profileGroups.push(group)
             }
@@ -160,12 +161,14 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
 
         this.profileGroups.sort((a, b) => a.name?.localeCompare(b.name ?? '') ?? -1)
 
-        this.profileGroups.push({
+        const builtIn = {
             name: this.translate.instant('Built-in'),
             profiles: this.builtinProfiles,
             editable: false,
             collapsed: false,
-        })
+        }
+        builtIn.collapsed = profileGroupCollapsed[builtIn.name ?? ''] ?? false
+        this.profileGroups.push(builtIn)
     }
 
     async editGroup (group: ProfileGroup): Promise<void> {
@@ -244,6 +247,13 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
             telnet: 'info',
             'split-layout': 'primary',
         }[this.profilesService.providerForProfile(profile)?.id ?? ''] ?? 'warning'
+    }
+
+    toggleGroupCollapse (group: ProfileGroup): void {
+        group.collapsed = !group.collapsed
+        const profileGroupCollapsed = JSON.parse(window.localStorage.profileGroupCollapsed ?? '{}')
+        profileGroupCollapsed[group.name ?? ''] = group.collapsed
+        window.localStorage.profileGroupCollapsed = JSON.stringify(profileGroupCollapsed)
     }
 
     async editDefaults (provider: ProfileProvider<Profile>): Promise<void> {


### PR DESCRIPTION
Small quality of life improvement to remember which profile groups were collapsed.

Motivation:
I have many different connection profiles in many different groups that need to be modified/copied quite often hence starting at a partially collapsed view allows me to pickup where I stopped last time and ignore less relevant profiles easier.  