### PR TITLE
fix import lowcase host from ssh/config

### DIFF
--- a/tabby-electron/src/sshImporters.ts
+++ b/tabby-electron/src/sshImporters.ts
@@ -26,7 +26,7 @@ export class OpenSSHImporter extends SSHProfileImporter {
                 if (line.trim().startsWith('#') || !line.trim()) {
                     continue
                 }
-                if (line.startsWith('Host ')) {
+                if (line.toLowerCase().startsWith('host ')) {
                     if (currentProfile) {
                         results.push(currentProfile)
                     }


### PR DESCRIPTION
support import lowercase host field. from issue: https://github.com/Eugeny/tabby/issues/6219
```
Host upperhostfield
    ...

host lowerhostfield
   ....
```