### PR TITLE
add the "delete entire line" hotkey

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -244,6 +244,11 @@ export class BaseTerminalTabComponent extends BaseTabComponent implements OnInit
                         }[this.hostApp.platform])
                     })
                     break
+                case 'delete-line':
+                    this.forEachFocusedTerminalPane(tab => {
+                        tab.sendInput('\x1bw')
+                    })
+                    break
                 case 'delete-previous-word':
                     this.forEachFocusedTerminalPane(tab => {
                         tab.sendInput('\x1b\x7f')

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -104,6 +104,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'previous-word': ['⌥-Left'],
                 'next-word': ['⌥-Right'],
                 'delete-previous-word': ['⌥-Backspace'],
+                'delete-line': ['⌘-Backspace'],
                 'delete-next-word': ['⌥-Delete'],
                 search: [
                     '⌘-F',
@@ -147,6 +148,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'previous-word': ['Ctrl-Left'],
                 'next-word': ['Ctrl-Right'],
                 'delete-previous-word': ['Ctrl-Backspace'],
+                'delete-line': ['Ctrl-Shift-Backspace'],
                 'delete-next-word': ['Ctrl-Delete'],
                 search: [
                     'Ctrl-Shift-F',
@@ -188,6 +190,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'previous-word': ['Ctrl-Left'],
                 'next-word': ['Ctrl-Right'],
                 'delete-previous-word': ['Ctrl-Backspace'],
+                'delete-line': ['Ctrl-Shift-Backspace'],
                 'delete-next-word': ['Ctrl-Delete'],
                 search: [
                     'Ctrl-Shift-F',

--- a/tabby-terminal/src/hotkeys.ts
+++ b/tabby-terminal/src/hotkeys.ts
@@ -34,6 +34,10 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
             name: this.translate.instant('Delete previous word'),
         },
         {
+            id: 'delete-line',
+            name: this.translate.instant('Delete entire line'),
+        },
+        {
             id: 'delete-next-word',
             name: this.translate.instant('Delete next word'),
         },


### PR DESCRIPTION
This enhancement PR is for adding the hotkey/shortcut to delete the entire line directly, via `⌘-Backspace` or `Ctrl-Shift-Backspace`.

Close #5959 