### PR TITLE
Hide description in selector modal if it's the same as the title

### DIFF
--- a/tabby-core/src/components/selectorModal.component.pug
+++ b/tabby-core/src/components/selectorModal.component.pug
@@ -22,7 +22,9 @@
                     [color]='option.color'
                 )
                 .title.mr-2 {{getOptionText(option)}}
-                .description.no-wrap.text-muted {{option.description}}
+                .description.no-wrap.text-muted(
+                    *ngIf='option.description !== getOptionText(option)'
+                ) {{option.description}}
                 .ml-auto
                 .no-wrap.badge.badge-secondary.text-muted.ml-2(*ngIf='selectedIndex == i && canEditSelected()')
                     span Backspace


### PR DESCRIPTION
I have a lot of SSH profiles where the name of the profile is the same as the SSH hostname, which clutters the UI. This PR cleans it up a bit by hiding the description (hostname) if it is the same as the title (name of profile).