### PR TITLE
Save downloaded config (fix #6694)

### DIFF
--- a/app/lib/app.ts
+++ b/app/lib/app.ts
@@ -31,7 +31,7 @@ export class Application {
         this.useBuiltinGraphics()
         this.ptyManager.init(this)
 
-        ipcMain.on('app:save-config', async (event, config) => {
+        ipcMain.handle('app:save-config', async (event, config) => {
             await saveConfig(config)
             this.broadcastExcept('host:config-change', event.sender, config)
         })

--- a/tabby-electron/src/services/hostApp.service.ts
+++ b/tabby-electron/src/services/hostApp.service.ts
@@ -58,8 +58,8 @@ export class ElectronHostAppService extends HostAppService {
         this.electron.ipcRenderer.send('app:new-window')
     }
 
-    saveConfig (data: string): void {
-        this.electron.ipcRenderer.send('app:save-config', data)
+    async saveConfig (data: string): Promise<void> {
+        await this.electron.ipcRenderer.invoke('app:save-config', data)
     }
 
     emitReady (): void {

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -109,7 +109,7 @@ export class ElectronPlatformService extends PlatformService {
     }
 
     async saveConfig (content: string): Promise<void> {
-        this.hostApp.saveConfig(content)
+        await this.hostApp.saveConfig(content)
     }
 
     getConfigPath (): string|null {


### PR DESCRIPTION
The downloaded config may fail to be saved because of a race condition in writeConfigDataFromSync().
Inside this function, the first line `await this.platform.saveConfig(yaml.dump(data)) `performs the save action in an async way (ipcRenderer.send / ipcMain.on). It is possible that the new config is not saved before invoking `await this.config.load()`, causing it to load the old config and then override the config file in `await this.config.save()`.

This commit replaces (ipcRenderer.send / ipcMain.on) with (ipcRenderer.invoke / ipcMain.handle) to ensure that the new config is saved first.