### PR TITLE
Replace npms to official npm registry & fix isOfficial badge in plugin-manager

### DIFF
--- a/tabby-plugin-manager/src/services/pluginManager.service.ts
+++ b/tabby-plugin-manager/src/services/pluginManager.service.ts
@@ -62,7 +62,7 @@ export class PluginManagerService {
                     version: item.package.version,
                     homepage: item.package.links.homepage,
                     author: (item.package.author || {}).name,
-                    isOfficial: item.package.publisher.name === OFFICIAL_NPM_ACCOUNT,
+                    isOfficial: item.package.publisher.username === OFFICIAL_NPM_ACCOUNT,
                 }))
             ),
             map(plugins => plugins.filter(x => x.packageName.startsWith(namePrefix))),

--- a/tabby-plugin-manager/src/services/pluginManager.service.ts
+++ b/tabby-plugin-manager/src/services/pluginManager.service.ts
@@ -51,9 +51,9 @@ export class PluginManagerService {
 
     _listAvailableInternal (namePrefix: string, keyword: string, query?: string): Observable<PluginInfo[]> {
         return from(
-            axios.get(`https://api.npms.io/v2/search?q=keywords%3A${keyword}+${encodeURIComponent(query ?? '')}&size=250`)
+            axios.get(`https://registry.npmjs.com/-/v1/search?text=keywords%3A${keyword}%20${query}&size=250`)
         ).pipe(
-            map(response => response.data.results
+            map(response => response.data.objects
                 .filter(item => !item.keywords?.includes('tabby-dummy-transition-plugin'))
                 .map(item => ({
                     name: item.package.name.substring(namePrefix.length),


### PR DESCRIPTION
Hi,

First, thank you for this wonderful teminal !

I removed npms registry from the plugins-manager because of a wrong version display.
See [issue](https://github.com/Eugeny/tabby/issues/6854) 

I switched to the official npm registry (docs available [here](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md)).


---- 

I also fixed the bool isOfficial which is incorect in both registry. 
Example for [npms](https://api.npms.io/v2/search?q=terminus-clickable-links) and [npm registry](https://registry.npmjs.com/-/v1/search?text=keywords:terminus-plugin%20terminus-clickable-links&size=250) there is no `publisher.name` but `publisher.username`.


Result : 

<img width="607" alt="Capture d’écran 2022-08-20 à 21 50 28" src="https://user-images.githubusercontent.com/19855907/185763901-53bfe40e-c61a-48d0-99b2-69e5160de2c7.png">

Instead of :

<img width="452" alt="Capture d’écran 2022-08-20 à 21 51 05" src="https://user-images.githubusercontent.com/19855907/185763927-1f10daf3-4114-4465-a0bd-5e7992c89e1c.png">





