### PR TITLE
Add EditorConfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sln]
+indent_style = tab
+# TODO Determine if there is a preferred tab width for this file type
+
+# Programming/Scripts
+[*.{js,ts}]
+indent_style = space
+indent_size = 4
+
+[*.cpp]
+indent_style = tab
+# TODO Determine if there is a preferred tab width for this file type
+
+# Markup
+[*.pug]
+indent_style = space
+indent_size = 4
+
+# Stylesheets
+[*.scss]
+indent_style = space
+indent_size = 4
+
+# Data Files
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/tabby-community-color-schemes/.editorconfig
+++ b/tabby-community-color-schemes/.editorconfig
@@ -1,0 +1,3 @@
+[schemes/*]
+indent_style = space
+indent_size = 15


### PR DESCRIPTION
[EditorConfig][editorconfig] is a plugin that allows you to use a configuration file to keep editor behavior uniform. This can save developers the trouble of needing to lint files to match some basic formatting (often indentation). It's available in [many editors by default](https://editorconfig.org/#pre-installed), and can be [enabled with a plugin for other editors](https://editorconfig.org/#download).

This sets the indentation size of various filetypes common in this project. The preferred tab width for tab-indented files is unknown, so `TODO` comments have been left there.

This helps keep uniform behavior in any text editor that has EditorConfig enabled.

Additionally, the tab width provided for color scheme files makes it easier to align hex values when editing a file manually.

[editorconfig]: https://editorconfig.org/
