### PR TITLE
use winSCP.com utility to convert private key to ppk to launch winSCP

### DIFF
--- a/tabby-ssh/package.json
+++ b/tabby-ssh/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@luminati-io/socksv5": "^0.0.7",
-    "node-forge": "^1.3.1",
     "run-script-os": "^1.1.3",
     "tmp-promise": "^3.0.3"
   },

--- a/tabby-ssh/src/services/ssh.service.ts
+++ b/tabby-ssh/src/services/ssh.service.ts
@@ -2,8 +2,6 @@ import * as shellQuote from 'shell-quote'
 import * as net from 'net'
 import * as fs from 'fs/promises'
 import * as tmp from 'tmp-promise'
-import * as sshpk from 'sshpk'
-import * as forge from 'node-forge'
 import socksv5 from '@luminati-io/socksv5'
 import { Duplex } from 'stream'
 import { Injectable } from '@angular/core'
@@ -53,10 +51,9 @@ export class SSHService {
         let tmpFile: tmp.FileResult|null = null
         if (session.activePrivateKey) {
             tmpFile = await tmp.file()
-            const privateKey = await sshpk.parsePrivateKey(session.activePrivateKey, 'auto')/* .toString('putty') */
-            const forgePrivateKey = forge.pki.decryptRsaPrivateKey(privateKey.toString('pem'))
-            const ppk = forge.ssh.privateKeyToPutty(forgePrivateKey)
-            await fs.writeFile(tmpFile.path, ppk)
+            await fs.writeFile(tmpFile.path, session.activePrivateKey)
+            const winSCPcom = path.slice(0, -3) + 'com'
+            await this.platform.exec(winSCPcom, ['/keygen', tmpFile.path, `/output=${tmpFile.path}`])
             args.push(`/privatekey=${tmpFile.path}`)
         }
         await this.platform.exec(path, args)

--- a/tabby-ssh/yarn.lock
+++ b/tabby-ssh/yarn.lock
@@ -214,11 +214,6 @@ minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-node-forge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
Fixes #7204

Using [winSCP.com](https://winscp.net/eng/docs/executables#winscp.com) utility that comes with winSCP to convert private key to ppk for winSCP connection for it's support of many different types of key types(RSA, DSA, ECDSA, Ed25519).
As an additional improvement it could show error message in case something goes wrong in a popup/modal rather than just in the console, but I didn't make that more involved change.

Tested with rsa, ecdsa and ed25519 keys in different formats, both password protected and passwordless(sshpk takes care of unencrypting the key beforehand).
Drop node-forge dependency as redundant.