### PR TITLE
Mark duplicate hotkeys

### DIFF
--- a/tabby-core/src/api/hotkeyProvider.ts
+++ b/tabby-core/src/api/hotkeyProvider.ts
@@ -3,6 +3,11 @@ export interface HotkeyDescription {
     name: string
 }
 
+export interface Hotkey {
+    strokes: string[] | string; // may be a sequence of strokes
+    isDuplicate: boolean;
+}
+
 /**
  * Extend to provide your own hotkeys. A corresponding [[ConfigProvider]]
  * must also provide the `hotkeys.foo` config options with the default values

--- a/tabby-core/src/api/index.ts
+++ b/tabby-core/src/api/index.ts
@@ -5,7 +5,7 @@ export { SplitTabComponent, SplitContainer, SplitDirection, SplitOrientation } f
 export { TabRecoveryProvider, RecoveryToken } from './tabRecovery'
 export { ToolbarButtonProvider, ToolbarButton } from './toolbarButtonProvider'
 export { ConfigProvider } from './configProvider'
-export { HotkeyProvider, HotkeyDescription } from './hotkeyProvider'
+export { HotkeyProvider, HotkeyDescription, Hotkey } from './hotkeyProvider'
 export { Theme } from './theme'
 export { TabContextMenuItemProvider } from './tabContextMenuProvider'
 export { SelectorOption } from './selector'

--- a/tabby-core/src/theme.paper.scss
+++ b/tabby-core/src/theme.paper.scss
@@ -256,6 +256,11 @@ multi-hotkey-input {
         }
     }
 
+    .item:has(.duplicate) {
+        background-color: theme-color('danger');
+        border: 1px solid theme-color('danger');
+    }
+
     .add {
         color: #777;
         padding: 4px 10px 0;
@@ -264,6 +269,11 @@ multi-hotkey-input {
     .add, .item .body, .item .remove {
         &:hover { background: darken($body-bg2, 5%); }
         &:active { background: darken($body-bg2, 15%); }
+    }
+
+    .add:has(.duplicate), .item:has(.duplicate) .body, .item:has(.duplicate) .remove {
+        &:hover { background: darken(theme-color('danger'), 5%); }
+        &:active { background: darken(theme-color('danger'), 15%); }
     }
 }
 

--- a/tabby-core/src/theme.scss
+++ b/tabby-core/src/theme.scss
@@ -162,6 +162,11 @@ multi-hotkey-input {
         }
     }
 
+    .item:has(.duplicate) {
+        background-color: theme-color('danger');
+        border: 1px solid theme-color('danger');
+    }
+
     .add {
         color: #777;
         padding: 4px 10px 0;
@@ -170,6 +175,11 @@ multi-hotkey-input {
     .add, .item .body, .item .remove {
         &:hover { background: darken($body-bg2, 5%); }
         &:active { background: darken($body-bg2, 15%); }
+    }
+
+    .add:has(.duplicate), .item:has(.duplicate) .body, .item:has(.duplicate) .remove {
+        &:hover { background: darken(theme-color('danger'), 5%); }
+        &:active { background: darken(theme-color('danger'), 15%); }
     }
 }
 

--- a/tabby-settings/src/components/hotkeySettingsTab.component.pug
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.pug
@@ -14,6 +14,6 @@ h3.mb-3(translate) Hotkeys
                 span.ml-2.text-muted ({{hotkey.id}})
             .col-4.pr-5
                 multi-hotkey-input(
-                    [model]='getHotkey(hotkey.id) || []',
-                    (modelChange)='setHotkey(hotkey.id, $event)'
+                    [hotkeys]='getHotkeys(hotkey.id) || []',
+                    (hotkeysChange)='setHotkeys(hotkey.id, $event)'
                 )

--- a/tabby-settings/src/components/hotkeySettingsTab.component.ts
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.ts
@@ -3,11 +3,12 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, NgZone } from '@angular/core'
 import {
     ConfigService,
+    Hotkey,
     HotkeyDescription,
     HotkeysService,
     HostAppService,
 } from 'tabby-core'
-import { Hotkey } from 'tabby-core/src/api/hotkeyProvider'
+import deepEqual from 'deep-equal'
 
 _('Search hotkeys')
 
@@ -66,7 +67,7 @@ export class HotkeySettingsTabComponent {
             .flat()
 
         const isDuplicate = allHotkeys
-            .filter(hotkey => JSON.stringify(hotkey) === JSON.stringify(strokes))
+            .filter(hotkey => deepEqual(hotkey, strokes))
             .length > 1
 
         return { strokes, isDuplicate }

--- a/tabby-settings/src/components/multiHotkeyInput.component.pug
+++ b/tabby-settings/src/components/multiHotkeyInput.component.pug
@@ -1,6 +1,8 @@
-.item(*ngFor='let item of model')
-    .body((click)='editItem(item)')
-        .stroke(*ngFor='let stroke of item') {{stroke}}
-    .remove((click)='removeItem(item)') &times;
+.item(*ngFor='let hotkey of hotkeys')
+    .body((click)='editItem(hotkey)')
+        .stroke(*ngFor='let stroke of hotkey.strokes')
+            span(*ngIf='!hotkey.isDuplicate', translate) {{stroke}}
+            span.duplicate(*ngIf='hotkey.isDuplicate', translate) {{stroke}}
+    .remove((click)='removeItem(hotkey)') &times;
 
 .add((click)='addItem()', translate) Add...

--- a/tabby-settings/src/components/multiHotkeyInput.component.ts
+++ b/tabby-settings/src/components/multiHotkeyInput.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core'
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { HotkeyInputModalComponent } from './hotkeyInputModal.component'
-import { Hotkey } from 'tabby-core/src/api/hotkeyProvider'
+import { Hotkey } from 'tabby-core'
+import deepEqual from 'deep-equal'
 
 /** @hidden */
 @Component({
@@ -24,7 +25,7 @@ export class MultiHotkeyInputComponent {
 
     editItem (item: Hotkey): void {
         this.ngbModal.open(HotkeyInputModalComponent).result.then((newStrokes: string[]) => {
-            this.hotkeys.find(hotkey => this.isEqual(hotkey, item))!.strokes = newStrokes
+            this.hotkeys.find(hotkey => deepEqual(hotkey.strokes, item.strokes))!.strokes = newStrokes
             this.storeUpdatedHotkeys()
         })
     }
@@ -43,9 +44,5 @@ export class MultiHotkeyInputComponent {
 
     private storeUpdatedHotkeys () {
         this.hotkeysChange.emit(this.hotkeys)
-    }
-
-    private isEqual (h: Hotkey, item: Hotkey) {
-        return JSON.stringify(h.strokes) === JSON.stringify(item.strokes)
     }
 }

--- a/tabby-settings/src/components/multiHotkeyInput.component.ts
+++ b/tabby-settings/src/components/multiHotkeyInput.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { HotkeyInputModalComponent } from './hotkeyInputModal.component'
+import { Hotkey } from 'tabby-core/src/api/hotkeyProvider'
 
 /** @hidden */
 @Component({
@@ -10,37 +11,41 @@ import { HotkeyInputModalComponent } from './hotkeyInputModal.component'
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MultiHotkeyInputComponent {
-    @Input() model: string[][] = []
-    @Output() modelChange = new EventEmitter()
+    @Input() hotkeys: Hotkey[] = []
+    @Output() hotkeysChange = new EventEmitter()
 
     constructor (
         private ngbModal: NgbModal,
     ) { }
 
     ngOnChanges (): void {
-        if (typeof this.model === 'string') {
-            this.model = [this.model]
-        }
-        this.model = this.model.map(item => typeof item === 'string' ? [item] : item)
+        this.hotkeys = this.hotkeys.map(hotkey => typeof hotkey.strokes === 'string' ? { ...hotkey, strokes: [hotkey.strokes] } : hotkey)
     }
 
-    editItem (item: string[]): void {
-        this.ngbModal.open(HotkeyInputModalComponent).result.then((value: string[]) => {
-            this.model[this.model.findIndex(x => x === item)] = value
-            this.model = this.model.slice()
-            this.modelChange.emit(this.model)
+    editItem (item: Hotkey): void {
+        this.ngbModal.open(HotkeyInputModalComponent).result.then((newStrokes: string[]) => {
+            this.hotkeys.find(hotkey => this.isEqual(hotkey, item))!.strokes = newStrokes
+            this.storeUpdatedHotkeys()
         })
     }
 
     addItem (): void {
         this.ngbModal.open(HotkeyInputModalComponent).result.then((value: string[]) => {
-            this.model = this.model.concat([value])
-            this.modelChange.emit(this.model)
+            this.hotkeys.push({ strokes: value, isDuplicate: false })
+            this.storeUpdatedHotkeys()
         })
     }
 
-    removeItem (item: string[]): void {
-        this.model = this.model.filter(x => x !== item)
-        this.modelChange.emit(this.model)
+    removeItem (item: Hotkey): void {
+        this.hotkeys = this.hotkeys.filter(x => x !== item)
+        this.storeUpdatedHotkeys()
+    }
+
+    private storeUpdatedHotkeys () {
+        this.hotkeysChange.emit(this.hotkeys)
+    }
+
+    private isEqual (h: Hotkey, item: Hotkey) {
+        return JSON.stringify(h.strokes) === JSON.stringify(item.strokes)
     }
 }


### PR DESCRIPTION
Feature to mark duplicate hotkeys. Solves https://github.com/Eugeny/tabby/issues/2704.

![hotkey_duplicates](https://user-images.githubusercontent.com/17959794/208317092-db293f01-2d9b-4937-af18-ddc3c152e4d8.gif)
