### PR TITLE
fix Eugeny/tabby#7254 - config sync replace ngModelChange by keydown enter

### DIFF
--- a/tabby-settings/src/components/configSyncSettingsTab.component.pug
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.pug
@@ -12,7 +12,7 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                     input.form-control(
                         type='text',
                         [(ngModel)]='config.store.configSync.host',
-                        (ngModelChange)='config.save()',
+                        (keydown.enter)='config.save()',
                     )
                     .input-group-append(*ngIf='config.store.configSync.host')
                         button.btn.btn-secondary((click)='openSyncHost()')
@@ -27,7 +27,7 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                     input.form-control(
                         type='password',
                         [(ngModel)]='config.store.configSync.token',
-                        (ngModelChange)='config.save(); testConnection()'
+                        (keydown.enter)='config.save(); testConnection()'
                     )
                     .input-group-append(*ngIf='config.store.configSync.token')
                         .input-group-text


### PR DESCRIPTION
Hi,

First of all, thank's for the work on Tabby. I really love it !

I encountered the same problem as the one describe in the issue #7254.
This fix seems acceptable to me since we don't need to save the config and test the connection on each inserted or removed character in the host and token input field. But i possibly missed something so feel free to ask me if any change needed :)

