### PR TITLE
feat: publish typings for tabby-ssh

### DIFF
--- a/tabby-ssh/package.json
+++ b/tabby-ssh/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "util/pagent.exe"
+    "util/pagent.exe",
+    "typings"
   ],
   "author": "Eugene Pankov",
   "license": "MIT",


### PR DESCRIPTION
I'm developing a small plugin for Tabby (one that fetches instance data from AWS in order to make it easier to start SSH connections), and I found out that, even though the `tabby-ssh` plugin is written in Typescript and has typings declared in the `package.json`, those typings are not included when publishing the package. This makes development of plugins that consume the `tabby-ssh` plugin API a bit harder.

This change includes the `typings` folder in the `tabby-ssh` package, so the Typescript type definition files are bundled in it.

To be honest this probably should be done for all the plugins in this repo, but I've only checked `tabby-ssh`. I'm open to include those other plugins in this PR if you consider that useful.