### PR TITLE
feat(tabby-ssh): use string token for providing SSHProfileImporter

### DIFF
--- a/tabby-electron/src/index.ts
+++ b/tabby-electron/src/index.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core'
 import { PlatformService, LogService, UpdaterService, DockingService, HostAppService, ThemesService, Platform, AppService, ConfigService, WIN_BUILD_FLUENT_BG_SUPPORTED, isWindowsBuild, HostWindowService, HotkeyProvider, ConfigProvider, FileProvider } from 'tabby-core'
 import { TerminalColorSchemeProvider } from 'tabby-terminal'
-import { SFTPContextMenuItemProvider, SSHProfileImporter, AutoPrivateKeyLocator } from 'tabby-ssh'
+import { SFTPContextMenuItemProvider, AutoPrivateKeyLocator, SSH_PROFILE_IMPORTER } from 'tabby-ssh'
 import { auditTime } from 'rxjs'
 
 import { HyperColorSchemes } from './colorSchemes'
@@ -32,8 +32,8 @@ import { OpenSSHImporter, PrivateKeyLocator, StaticFileImporter } from './sshImp
         { provide: ConfigProvider, useClass: ElectronConfigProvider, multi: true },
         { provide: FileProvider, useClass: ElectronFileProvider, multi: true },
         { provide: SFTPContextMenuItemProvider, useClass: EditSFTPContextMenu, multi: true },
-        { provide: SSHProfileImporter, useExisting: OpenSSHImporter, multi: true },
-        { provide: SSHProfileImporter, useExisting: StaticFileImporter, multi: true },
+        { provide: SSH_PROFILE_IMPORTER, useExisting: OpenSSHImporter, multi: true },
+        { provide: SSH_PROFILE_IMPORTER, useExisting: StaticFileImporter, multi: true },
         { provide: AutoPrivateKeyLocator, useExisting: PrivateKeyLocator, multi: true },
     ],
 })

--- a/tabby-ssh/src/api/importer.ts
+++ b/tabby-ssh/src/api/importer.ts
@@ -1,6 +1,8 @@
 import { PartialProfile } from 'tabby-core'
 import { SSHProfile } from './interfaces'
 
+export const SSH_PROFILE_IMPORTER = 'tabby-ssh:SSHProfileImporter'
+
 export abstract class SSHProfileImporter {
     abstract getProfiles (): Promise<PartialProfile<SSHProfile>[]>
 }

--- a/tabby-ssh/src/profiles.ts
+++ b/tabby-ssh/src/profiles.ts
@@ -4,7 +4,7 @@ import * as ALGORITHMS from 'ssh2/lib/protocol/constants'
 import { SSHProfileSettingsComponent } from './components/sshProfileSettings.component'
 import { SSHTabComponent } from './components/sshTab.component'
 import { PasswordStorageService } from './services/passwordStorage.service'
-import { ALGORITHM_BLACKLIST, SSHAlgorithmType, SSHProfile } from './api'
+import { ALGORITHM_BLACKLIST, SSH_PROFILE_IMPORTER, SSHAlgorithmType, SSHProfile } from './api'
 import { SSHProfileImporter } from './api/importer'
 
 @Injectable({ providedIn: 'root' })
@@ -65,7 +65,7 @@ export class SSHProfilesService extends ProfileProvider<SSHProfile> {
     }
 
     async getBuiltinProfiles (): Promise<PartialProfile<SSHProfile>[]> {
-        const importers = this.injector.get<SSHProfileImporter[]>(SSHProfileImporter as any, [], InjectFlags.Optional)
+        const importers = this.injector.get<SSHProfileImporter[]>(SSH_PROFILE_IMPORTER as any, [], InjectFlags.Optional)
         let imported: PartialProfile<SSHProfile>[] = []
         for (const importer of importers) {
             try {


### PR DESCRIPTION
Until now we were using a Type Token (class SSHProfileImporter) to inject importers into the SSHProfilesService. However, this made external plugins unable of providing their own importers, since the reference to SSHProfileImporter from the built-in plugins was different to the one from any external plugin.

This probably has to do with webpack bundling different "instances" of the class SSHProfileImporter between built-in and external plugins. The implementation was the same (since the class was being imported from the tabby-ssh package), but the memory reference was different, so the dependency injector wouldn't match the external ones.

By using a string as DI Token, we ensure plugins can use a token that the injector can match, since strings are compared by value instead of reference.