### PR TITLE
feat: add button to delete remote config sync

### DIFF
--- a/tabby-settings/src/components/configSyncSettingsTab.component.pug
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.pug
@@ -77,6 +77,12 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                             )
                                 i.fas.fa-arrow-down
                                 span.ml-2(translate) Download
+                            button.btn.btn-link.ml-1(
+                                (click)='delete(cfg)',
+                                [class.hover-reveal]='!isActiveConfig(cfg)'
+                            )
+                                i.fas.fa-trash
+                                span.ml-2(translate) Delete
                         a.list-group-item.list-group-item-action.d-flex.align-items-center(
                             href='#',
                             (click)='uploadAsNew()'

--- a/tabby-settings/src/components/configSyncSettingsTab.component.ts
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.ts
@@ -112,9 +112,9 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
         if ((await this.platform.showMessageBox({
             type: 'warning',
             message: this.translate.instant('Delete the config on the remote side?'),
-                buttons: [
-                    this.translate.instant('Delete'),
-                    this.translate.instant('Cancel'),
+            buttons: [
+                this.translate.instant('Delete'),
+                this.translate.instant('Cancel'),
             ],
             defaultId: 1,
             cancelId: 1,

--- a/tabby-settings/src/components/configSyncSettingsTab.component.ts
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.ts
@@ -108,6 +108,24 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
         this.notifications.info(this.translate.instant('Config downloaded'))
     }
 
+    async delete (cfg: Config) {
+        if ((await this.platform.showMessageBox({
+            type: 'warning',
+            message: this.translate.instant('Delete the config on the remote side?'),
+                buttons: [
+                    this.translate.instant('Delete'),
+                    this.translate.instant('Cancel'),
+            ],
+            defaultId: 1,
+            cancelId: 1,
+        })).response === 1) {
+            return
+        }
+        await this.configSync.delete(cfg)
+        this.loadConfigs()
+        this.notifications.info(this.translate.instant('Config deleted'))
+    }
+
     hasMatchingRemoteConfig () {
         return !!this.configs?.find(c => this.isActiveConfig(c))
     }

--- a/tabby-settings/src/services/configSync.service.ts
+++ b/tabby-settings/src/services/configSync.service.ts
@@ -75,6 +75,10 @@ export class ConfigSyncService {
         })
     }
 
+    async deleteConfig (id: number): Promise<any> {
+        return this.request('DELETE', `/api/1/configs/${id}`)
+    }
+
     setConfig (config: Config): void {
         this.config.store.configSync.configID = config.id
         this.config.save()
@@ -133,6 +137,16 @@ export class ConfigSyncService {
         }
     }
 
+    async delete (config: Config): Promise<void> {
+        try {
+            await this.deleteConfig(config.id)
+            this.logger.debug('Config deleted')
+        } catch (error) {
+            this.logger.error('Delete failed:', error)
+            throw error
+        }
+    }
+
     private async readConfigDataForSync (): Promise<any> {
         const data = yaml.load(await this.platform.loadConfig()) as any
         delete data.configSync
@@ -145,7 +159,7 @@ export class ConfigSyncService {
         await this.config.save()
     }
 
-    private async request (method: 'GET'|'POST'|'PATCH', url: string, params = {}) {
+    private async request (method: 'GET'|'POST'|'PATCH'|'DELETE', url: string, params = {}) {
         if (this.config.store.configSync.host.endsWith('/')) {
             this.config.store.configSync.host = this.config.store.configSync.host.slice(0, -1)
         }


### PR DESCRIPTION
Hi @Eugeny,

Hope you're doing well !

I think it would be great to be able to delete synch configuration directly from tabby client.
This PR simply add a button to delete the config from the API. I deliberately did not clean config on the client side when deleting as it was more appropriate to do like that in my mind. Feel free ta ask me if change are needed :)

![image](https://user-images.githubusercontent.com/20025949/215508314-2997cd56-baf3-4f51-9f93-79436c088b5a.png) 
