### PR TITLE
fix: prevent backspace in profile selection

### DIFF
--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -47,6 +47,7 @@ export class SelectorModalComponent<T> {
             this.close()
         }
         if (event.key === 'Backspace' && this.canEditSelected()) {
+            event.preventDefault()
             this.filter = this.filteredOptions[this.selectedIndex].freeInputEquivalent!
             this.onFilterChange()
         }


### PR DESCRIPTION
Hello hello,

It's me again :D

I thought it would be a good idea to prevent the backspace event in the profile selection field when the filter is empty and the selected profile editable. Without preventing it, the last character of the address is deleted.

![image](https://user-images.githubusercontent.com/20025949/215572710-a13143d9-0108-47e7-89d2-3a5cd6477598.png)

Backspace result in 1.0.188:
![image](https://user-images.githubusercontent.com/20025949/215570972-36d97e13-eec7-4666-955a-c7e895f891d9.png)

Backspace result with this commit:
![image](https://user-images.githubusercontent.com/20025949/215572606-cfdd9c71-b551-4737-84ef-72338c62f1db.png)



