### PR TITLE
 fix #4684 - removing profile's hotkeys on profile delete

### DIFF
--- a/tabby-core/src/api/hotkeyProvider.ts
+++ b/tabby-core/src/api/hotkeyProvider.ts
@@ -1,3 +1,5 @@
+import { PartialProfile, Profile } from './profileProvider'
+
 export interface HotkeyDescription {
     id: string
     name: string
@@ -14,4 +16,8 @@ export interface Hotkey {
  */
 export abstract class HotkeyProvider {
     abstract provide (): Promise<HotkeyDescription[]>
+
+    static getProfileHotkeyName (profile: PartialProfile<Profile>): string {
+        return (profile.id ?? profile.name).replace(/\./g, '-')
+    }
 }

--- a/tabby-core/src/hotkeys.ts
+++ b/tabby-core/src/hotkeys.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { ProfilesService } from './services/profiles.service'
 import { HotkeyDescription, HotkeyProvider } from './api/hotkeyProvider'
-import { PartialProfile, Profile } from './api'
 
 /** @hidden */
 @Injectable()
@@ -268,7 +267,7 @@ export class AppHotkeyProvider extends HotkeyProvider {
         return [
             ...this.hotkeys,
             ...profiles.map(profile => ({
-                id: `profile.${AppHotkeyProvider.getProfileHotkeyName(profile)}`,
+                id: `profile.${HotkeyProvider.getProfileHotkeyName(profile)}`,
                 name: this.translate.instant('New tab: {profile}', { profile: profile.name }),
             })),
             ...this.profilesService.getProviders().map(provider => ({
@@ -278,7 +277,4 @@ export class AppHotkeyProvider extends HotkeyProvider {
         ]
     }
 
-    static getProfileHotkeyName (profile: PartialProfile<Profile>): string {
-        return (profile.id ?? profile.name).replace(/\./g, '-')
-    }
 }

--- a/tabby-core/src/index.ts
+++ b/tabby-core/src/index.ts
@@ -184,7 +184,7 @@ export default class AppModule { // eslint-disable-line @typescript-eslint/no-ex
             if (hotkey.startsWith('profile.')) {
                 const id = hotkey.substring(hotkey.indexOf('.') + 1)
                 const profiles = await profilesService.getProfiles()
-                const profile = profiles.find(x => AppHotkeyProvider.getProfileHotkeyName(x) === id)
+                const profile = profiles.find(x => HotkeyProvider.getProfileHotkeyName(x) === id)
                 if (profile) {
                     profilesService.openNewTabForProfile(profile)
                 }

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -4,7 +4,7 @@ import slugify from 'slugify'
 import deepClone from 'clone-deep'
 import { Component, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigService, HostAppService, Profile, SelectorService, ProfilesService, PromptModalComponent, PlatformService, BaseComponent, PartialProfile, ProfileProvider, TranslateService, Platform } from 'tabby-core'
+import { ConfigService, HostAppService, Profile, SelectorService, ProfilesService, PromptModalComponent, PlatformService, BaseComponent, PartialProfile, ProfileProvider, TranslateService, Platform, HotkeyProvider } from 'tabby-core'
 import { EditProfileModalComponent } from './editProfileModal.component'
 
 interface ProfileGroup {
@@ -146,6 +146,11 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
             this.profilesService.providerForProfile(profile)?.deleteProfile(
                 this.profilesService.getConfigProxyForProfile(profile))
             this.config.store.profiles = this.config.store.profiles.filter(x => x !== profile)
+            const profileHotkeyName = HotkeyProvider.getProfileHotkeyName(profile)
+            if (this.config.store.hotkeys.profile.hasOwnProperty(profileHotkeyName)) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete this.config.store.hotkeys.profile[profileHotkeyName]
+            }
             await this.config.save()
         }
     }


### PR DESCRIPTION
Hi @Eugeny,

This PR aims to fix the issue Eugeny/tabby#4684 by removing profile's hotkeys if some are present when the profile is deleted.
I moved the function `getProfileHotkeyName` in the abstract class HotkeyProvider. In that way, the function can be used through the api.

If I understood properly, using `delete` operator to dynamically remove keys from an object is not recommended. So feel free to ask if changes needed or if you want me to find a better way to delete hotkeys.