### PR TITLE
[feature] add reconnect tab to command palette and hotkey

### DIFF
--- a/tabby-core/src/configDefaults.linux.yaml
+++ b/tabby-core/src/configDefaults.linux.yaml
@@ -22,6 +22,7 @@ hotkeys:
     - 'Ctrl-Shift'
   duplicate-tab: []
   restart-tab: []
+  reconnect-tab: []
   explode-tab:
     - 'Ctrl-Shift-.'
   combine-tabs:

--- a/tabby-core/src/configDefaults.macos.yaml
+++ b/tabby-core/src/configDefaults.macos.yaml
@@ -39,6 +39,7 @@ hotkeys:
   tab-10: []
   duplicate-tab: []
   restart-tab: []
+  reconnect-tab: []
   explode-tab:
     - '⌘-Shift-.'
   combine-tabs:

--- a/tabby-core/src/configDefaults.windows.yaml
+++ b/tabby-core/src/configDefaults.windows.yaml
@@ -23,6 +23,7 @@ hotkeys:
     - 'Ctrl-Shift'
   duplicate-tab: []
   restart-tab: []
+  reconnect-tab: []
   explode-tab:
     - 'Ctrl-Shift-.'
   combine-tabs:

--- a/tabby-serial/src/components/serialTab.component.ts
+++ b/tabby-serial/src/components/serialTab.component.ts
@@ -4,7 +4,7 @@ import colors from 'ansi-colors'
 import { Component, Injector } from '@angular/core'
 import { first } from 'rxjs'
 import { GetRecoveryTokenOptions, Platform, SelectorService } from 'tabby-core'
-import { BaseTerminalTabComponent } from 'tabby-terminal'
+import { BaseTerminalTabComponent, Reconnectable } from 'tabby-terminal'
 import { SerialSession, BAUD_RATES, SerialProfile } from '../api'
 
 /** @hidden */
@@ -14,7 +14,7 @@ import { SerialSession, BAUD_RATES, SerialProfile } from '../api'
     styleUrls: ['./serialTab.component.scss', ...BaseTerminalTabComponent.styles],
     animations: BaseTerminalTabComponent.animations,
 })
-export class SerialTabComponent extends BaseTerminalTabComponent<SerialProfile> {
+export class SerialTabComponent extends BaseTerminalTabComponent<SerialProfile> implements Reconnectable {
     session: SerialSession|null = null
     Platform = Platform
 

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -4,7 +4,7 @@ import { Component, Injector, HostListener } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { first } from 'rxjs'
 import { GetRecoveryTokenOptions, Platform, ProfilesService, RecoveryToken } from 'tabby-core'
-import { BaseTerminalTabComponent } from 'tabby-terminal'
+import { BaseTerminalTabComponent, Reconnectable } from 'tabby-terminal'
 import { SSHService } from '../services/ssh.service'
 import { KeyboardInteractivePrompt, SSHSession } from '../session/ssh'
 import { SSHPortForwardingModalComponent } from './sshPortForwardingModal.component'
@@ -22,7 +22,7 @@ import { SSHMultiplexerService } from '../services/sshMultiplexer.service'
     ],
     animations: BaseTerminalTabComponent.animations,
 })
-export class SSHTabComponent extends BaseTerminalTabComponent<SSHProfile> {
+export class SSHTabComponent extends BaseTerminalTabComponent<SSHProfile> implements Reconnectable {
     Platform = Platform
     sshSession: SSHSession|null = null
     session: SSHShellSession|null = null

--- a/tabby-telnet/src/components/telnetTab.component.ts
+++ b/tabby-telnet/src/components/telnetTab.component.ts
@@ -3,7 +3,7 @@ import colors from 'ansi-colors'
 import { Component, Injector } from '@angular/core'
 import { first } from 'rxjs'
 import { GetRecoveryTokenOptions, Platform, RecoveryToken } from 'tabby-core'
-import { BaseTerminalTabComponent } from 'tabby-terminal'
+import { BaseTerminalTabComponent, Reconnectable } from 'tabby-terminal'
 import { TelnetProfile, TelnetSession } from '../session'
 
 
@@ -14,7 +14,7 @@ import { TelnetProfile, TelnetSession } from '../session'
     styleUrls: ['./telnetTab.component.scss', ...BaseTerminalTabComponent.styles],
     animations: BaseTerminalTabComponent.animations,
 })
-export class TelnetTabComponent extends BaseTerminalTabComponent<TelnetProfile> {
+export class TelnetTabComponent extends BaseTerminalTabComponent<TelnetProfile> implements Reconnectable {
     Platform = Platform
     session: TelnetSession|null = null
     private reconnectOffered = false

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -9,7 +9,7 @@ import { BaseSession } from '../session'
 
 import { Frontend } from '../frontends/frontend'
 import { XTermFrontend, XTermWebGLFrontend } from '../frontends/xtermFrontend'
-import { ResizeEvent, BaseTerminalProfile } from './interfaces'
+import { ResizeEvent, BaseTerminalProfile, isReconnectable } from './interfaces'
 import { TerminalDecorator } from './decorator'
 import { SearchPanelComponent } from '../components/searchPanel.component'
 import { MultifocusService } from '../services/multifocus.service'
@@ -305,6 +305,11 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     break
                 case 'scroll-to-bottom':
                     this.frontend?.scrollToBottom()
+                    break
+                case 'reconnect-tab':
+                    if (isReconnectable(this)) {
+                        this.reconnect()
+                    }
                     break
             }
         })

--- a/tabby-terminal/src/api/interfaces.ts
+++ b/tabby-terminal/src/api/interfaces.ts
@@ -19,3 +19,11 @@ export interface TerminalColorScheme {
 export interface BaseTerminalProfile extends Profile {
     terminalColorScheme?: TerminalColorScheme
 }
+
+export interface Reconnectable {
+    reconnect: () => Promise<void>;
+}
+
+export function tabIsReconnectable (object: any): object is Reconnectable {
+    return 'reconnect' in object
+}

--- a/tabby-terminal/src/api/interfaces.ts
+++ b/tabby-terminal/src/api/interfaces.ts
@@ -24,6 +24,7 @@ export interface Reconnectable {
     reconnect: () => Promise<void>;
 }
 
-export function tabIsReconnectable (object: any): object is Reconnectable {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function isReconnectable (object: any): object is Reconnectable {
     return 'reconnect' in object
 }

--- a/tabby-terminal/src/hotkeys.ts
+++ b/tabby-terminal/src/hotkeys.ts
@@ -97,6 +97,10 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
             id: 'scroll-to-bottom',
             name: this.translate.instant('Scroll terminal to bottom'),
         },
+        {
+            id: 'reconnect-tab',
+            name: this.translate.instant('Reconnect current tab (Serial/Telnet/SSH)'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }

--- a/tabby-terminal/src/index.ts
+++ b/tabby-terminal/src/index.ts
@@ -28,7 +28,7 @@ import { PathDropDecorator } from './features/pathDrop'
 import { ZModemDecorator } from './features/zmodem'
 import { TerminalConfigProvider } from './config'
 import { TerminalHotkeyProvider } from './hotkeys'
-import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu } from './tabContextMenu'
+import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu } from './tabContextMenu'
 
 import { Frontend } from './frontends/frontend'
 import { XTermFrontend, XTermWebGLFrontend } from './frontends/xtermFrontend'
@@ -58,6 +58,7 @@ import { TerminalCLIHandler } from './cli'
         { provide: TabContextMenuItemProvider, useClass: CopyPasteContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: MiscContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: LegacyContextMenu, multi: true },
+        { provide: TabContextMenuItemProvider, useClass: ReconnectContextMenu, multi: true },
 
         { provide: CLIHandler, useClass: TerminalCLIHandler, multi: true },
     ],

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,7 +1,7 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
-import { tabIsReconnectable } from './api/interfaces'
+import { isReconnectable } from './api/interfaces'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
 
@@ -97,7 +97,7 @@ export class ReconnectContextMenu extends TabContextMenuItemProvider {
     ) { super() }
 
     async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
-        if (tabIsReconnectable(tab)) {
+        if (isReconnectable(tab)) {
             return [
                 {
                     label: this.translate.instant('Reconnect'),

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,6 +1,7 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
+import { tabIsReconnectable } from './api/interfaces'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
 
@@ -87,6 +88,35 @@ export class MiscContextMenu extends TabContextMenuItemProvider {
 
 /** @hidden */
 @Injectable()
+export class ReconnectContextMenu extends TabContextMenuItemProvider {
+    weight = 1
+
+    constructor (
+        private translate: TranslateService,
+        private notifications: NotificationsService,
+    ) { super() }
+
+    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
+        if (tabIsReconnectable(tab)) {
+            return [
+                {
+                    label: this.translate.instant('Reconnect'),
+                    click: (): void => {
+                        setTimeout(() => {
+                            tab.reconnect()
+                            this.notifications.notice(this.translate.instant('Reconnect'))
+                        })
+                    },
+                },
+            ]
+        }
+        return []
+    }
+
+}
+
+/** @hidden */
+@Injectable()
 export class LegacyContextMenu extends TabContextMenuItemProvider {
     weight = 1
 
@@ -109,4 +139,5 @@ export class LegacyContextMenu extends TabContextMenuItemProvider {
         }
         return []
     }
+
 }


### PR DESCRIPTION
Hi @Eugeny,

This PR adds reconnect command into the palette like asked in #7723.

In the view to add this feature in the most generic way, I choose to create an interface named `Reconnectable` which Serial, Telnet and SSH tab component are implementing. With this approach, the reconnect command in only added if the current tab can be reconnected. It works as expected but as I am not really familiar with interface in typescript, I let you tell me if it is a correct way to proceed or not...

A more simple way would probably be to provide a context menu for each reconnectable tab (in tabby-serial, tabby-ssh and tabby-telnet).


Secondly, I also added an hotkey to reconnect the current tab. I saw that a restart tab hotkey already exists but it duplicates the current tab and close the old one. Since the restart and reconnect are two different behaviors and reconnect applicable to serial/ssh/telnet only, I thought it could be interesting to have the two options.

I hope i didn't miss anything this time, feel free to ask if any change needed.