### PR TITLE
fix #8297 - set selected text into search box on opening

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -212,6 +212,11 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                 this.showSearchPanel = true
                 setImmediate(() => {
                     const input = this.element.nativeElement.querySelector('.search-input')
+                    const selectedText = (this.frontend?.getSelection() ?? '').trim()
+                    if (input && selectedText.length) {
+                        input.value = selectedText
+                    }
+
                     input?.focus()
                     input?.select()
                 })


### PR DESCRIPTION
Hi,

As explained in #8297 , the selected text in terminal is not set into the search box when it opens.
This PR aims to fix this issue.




Fix #8297 