### PR TITLE
fix #8297 - prevent copying text when the selection is made by the search box

### DIFF
--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -69,6 +69,7 @@ export class XTermFrontend extends Frontend {
     private resizeHandler: () => void
     private configuredTheme: ITheme = {}
     private copyOnSelect = false
+    private preventNextOnSelectionChangeEvent = false
     private search = new SearchAddon()
     private searchState: SearchState = { resultCount: 0 }
     private fitAddon = new FitAddon()
@@ -116,8 +117,11 @@ export class XTermFrontend extends Frontend {
             this.title.next(title)
         })
         this.xterm.onSelectionChange(() => {
-            if (this.copyOnSelect && this.getSelection()) {
-                this.copySelection()
+            if (this.getSelection()) {
+                if (this.copyOnSelect && !this.preventNextOnSelectionChangeEvent) {
+                    this.copySelection()
+                }
+                this.preventNextOnSelectionChangeEvent = false
             }
         })
         this.xterm.onBell(() => {
@@ -444,12 +448,18 @@ export class XTermFrontend extends Frontend {
     }
 
     findNext (term: string, searchOptions?: SearchOptions): SearchState {
+        if (this.copyOnSelect) {
+            this.preventNextOnSelectionChangeEvent = true
+        }
         return this.wrapSearchResult(
             this.search.findNext(term, this.getSearchOptions(searchOptions)),
         )
     }
 
     findPrevious (term: string, searchOptions?: SearchOptions): SearchState {
+        if (this.copyOnSelect) {
+            this.preventNextOnSelectionChangeEvent = true
+        }
         return this.wrapSearchResult(
             this.search.findPrevious(term, this.getSearchOptions(searchOptions)),
         )


### PR DESCRIPTION
Sorry for the inconvenience. This PR comes next to #8331. 

> Hi @Clem-Fern - just to clarify the issue https://github.com/Eugeny/tabby/issues/8297 is not with search-box initialization with the selected text. The problem is when the search box is open (with some text) then if I do a new selection on the terminal window in order to copy it to clipboard, it does not copy the selected text to clipboard rather it takes the text from the search box which is not intended.
The search-box text should not interfere with the selection being copied to clipboard.

Thanks @nexional for the correction. 

This issue seems to only happen when the `Copy On Select` feature is enabled.
The idea here is to prevent the selected text to be copied when the selection is made by the findNext/findPrevious methods.

As I am not really familiar with xterm, I wasn't able to find if there's a way to prevent this from happening directly through the search addon api. Feel free to ask me if any changes are required.

Fix #8297