### PR TITLE
Fire manual keyup event when key is not Enter

### DIFF
--- a/tabby-core/src/services/hotkeys.service.ts
+++ b/tabby-core/src/services/hotkeys.service.ts
@@ -178,7 +178,7 @@ export class HotkeysService {
             this._key.next(getKeyName(eventData))
         })
 
-        if (process.platform === 'darwin' && eventData.metaKey && eventName === 'keydown' && !['Ctrl', 'Shift', altKeyName, metaKeyName].includes(keyName)) {
+        if (process.platform === 'darwin' && eventData.metaKey && eventName === 'keydown' && !['Ctrl', 'Shift', altKeyName, metaKeyName, 'Enter'].includes(keyName)) {
             // macOS will swallow non-modified keyups if Cmd is held down
             this.pushKeyEvent('keyup', nativeEvent)
         }


### PR DESCRIPTION
This is experimental change to fix #8071 

By adding a condition to check keyname for manual keyup event firing,
the bug is fixed but the side-effect is unpredictable as of now.