### PR TITLE
Improving tabby startup time

### DIFF
--- a/app/src/plugins.ts
+++ b/app/src/plugins.ts
@@ -255,8 +255,8 @@ export async function loadPlugins (foundPlugins: PluginInfo[], progress: Progres
             setTimeout(x, 50)
         }))
     }
-    progress(1, 1)
-
     await Promise.all(pluginsPromises)
+
+    progress(1, 1)
     return plugins
 }

--- a/app/src/plugins.ts
+++ b/app/src/plugins.ts
@@ -248,11 +248,11 @@ export async function loadPlugins (foundPlugins: PluginInfo[], progress: Progres
                 pluginModule.pluginName = foundPlugin.name
                 pluginModule.bootstrap = packageModule.bootstrap
                 plugins.push(pluginModule)
-                setTimeout(x, 50)
             } catch (error) {
                 console.error(`Could not load ${foundPlugin.name}:`, error)
             }
             setProgress()
+            setTimeout(x, 50)
         }))
     }
     progress(1, 1)


### PR DESCRIPTION
Hi @Eugeny,

I found some issues about how tabby can be slow to launch in some case (#6295 , #7390 , #6253 ).
After taking a quick look, I saw that installed plugins are loaded one after another at the app startup. 

This PR aim to improve the startup time by finding and loading the plugins simultaneously.

Startup on latest release with 0 plugins : ~2.9sec
Startup on latest release with 8 plugins : ~3.5sec

Startup on this PR with 0 plugins : ~2.3sec
Startup on this PR with 8 plugins : ~2.3sec

I've only have SSD so there is no huge gab on my side. (Tested on Debian 11, don't have other system on hand sorry :/)

As always, I am not sure theses changes are really relevant nor if it is a good approach to try to reduce the startup time. I hope you could give me a feedback on this when you got time :D

