### PR TITLE
Feat #6518: add disconnect current tab hotkey and context menu item

### DIFF
--- a/tabby-core/src/configDefaults.linux.yaml
+++ b/tabby-core/src/configDefaults.linux.yaml
@@ -23,6 +23,7 @@ hotkeys:
   duplicate-tab: []
   restart-tab: []
   reconnect-tab: []
+  disconnect-tab: []
   explode-tab:
     - 'Ctrl-Shift-.'
   combine-tabs:

--- a/tabby-core/src/configDefaults.macos.yaml
+++ b/tabby-core/src/configDefaults.macos.yaml
@@ -40,6 +40,7 @@ hotkeys:
   duplicate-tab: []
   restart-tab: []
   reconnect-tab: []
+  disconnect-tab: []
   explode-tab:
     - '⌘-Shift-.'
   combine-tabs:

--- a/tabby-core/src/configDefaults.windows.yaml
+++ b/tabby-core/src/configDefaults.windows.yaml
@@ -24,6 +24,7 @@ hotkeys:
   duplicate-tab: []
   restart-tab: []
   reconnect-tab: []
+  disconnect-tab: []
   explode-tab:
     - 'Ctrl-Shift-.'
   combine-tabs:

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -789,7 +789,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
      * Method called when session is closed.
      */
     protected onSessionClosed (destroyOnSessionClose = false): void {
-        if (destroyOnSessionClose || this.doesTabShouldBeDestroyedOnSessionClosed()) {
+        if (destroyOnSessionClose || this.shouldTabBeDestroyedOnSessionClose()) {
             this.destroy()
         }
     }
@@ -797,12 +797,9 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
     /**
      * Return true if tab should be destroyed on session closed.
      */
-    protected doesTabShouldBeDestroyedOnSessionClosed (): boolean {
+    protected shouldTabBeDestroyedOnSessionClose (): boolean {
         const behavior = this.profile.behaviorOnSessionEnd
-        if (behavior === 'close' || behavior === 'auto' && this.isSessionExplicitlyTerminated()) {
-            return true
-        }
-        return false
+        return behavior === 'close' || behavior === 'auto' && this.isSessionExplicitlyTerminated()
     }
 
     /**

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -772,10 +772,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
         })
 
         this.attachSessionHandler(this.session.closed$, () => {
-            const behavior = this.profile.behaviorOnSessionEnd
-            if (destroyOnSessionClose || behavior === 'close' || behavior === 'auto' && this.isSessionExplicitlyTerminated()) {
-                this.destroy()
-            }
+            this.onSessionClosed(destroyOnSessionClose)
         })
 
         this.attachSessionHandler(this.session.destroyed$, () => {
@@ -786,6 +783,26 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             this.platform.setClipboard({ text: content })
             this.notifications.notice(this.translate.instant('Copied'))
         })
+    }
+
+    /**
+     * Method called when session is closed.
+     */
+    protected onSessionClosed (destroyOnSessionClose = false): void {
+        if (destroyOnSessionClose || this.doesTabShouldBeDestroyedOnSessionClosed()) {
+            this.destroy()
+        }
+    }
+
+    /**
+     * Return true if tab should be destroyed on session closed.
+     */
+    protected doesTabShouldBeDestroyedOnSessionClosed (): boolean {
+        const behavior = this.profile.behaviorOnSessionEnd
+        if (behavior === 'close' || behavior === 'auto' && this.isSessionExplicitlyTerminated()) {
+            return true
+        }
+        return false
     }
 
     /**

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -68,7 +68,7 @@ export abstract class ConnectableTerminalTabComponent<P extends BaseTerminalProf
         if (this.frontend) {
             if (this.profile.behaviorOnSessionEnd === 'reconnect' && !this.isDisconnectedByHand) {
                 this.reconnect()
-            } else if (this.profile.behaviorOnSessionEnd === 'keep' || !this.doesTabShouldBeDestroyedOnSessionClosed()) {
+            } else if (this.profile.behaviorOnSessionEnd === 'keep' || !this.shouldTabBeDestroyedOnSessionClose()) {
                 this.offerReconnection()
             }
         }
@@ -93,11 +93,11 @@ export abstract class ConnectableTerminalTabComponent<P extends BaseTerminalProf
     /**
      * Return true if tab should be destroyed on session closed.
      */
-    protected doesTabShouldBeDestroyedOnSessionClosed (): boolean {
+    protected shouldTabBeDestroyedOnSessionClose (): boolean {
         if (this.isDisconnectedByHand) {
             return false
         }
-        return super.doesTabShouldBeDestroyedOnSessionClosed()
+        return super.shouldTabBeDestroyedOnSessionClose()
     }
 
     async getRecoveryToken (options?: GetRecoveryTokenOptions): Promise<RecoveryToken> {

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -22,8 +22,19 @@ export abstract class ConnectableTerminalTabComponent<P extends BaseTerminalProf
         super(injector)
 
         this.subscribeUntilDestroyed(this.hotkeys.hotkey$, hotkey => {
-            if (this.hasFocus && hotkey === 'reconnect-tab') {
-                this.reconnect()
+            if (!this.hasFocus) {
+                return
+            }
+
+            switch (hotkey) {
+                case 'reconnect-tab':
+                    this.reconnect()
+                    this.notifications.notice(this.translate.instant('Reconnect'))
+                    break
+                case 'disconnect-tab':
+                    this.disconnect()
+                    this.notifications.notice(this.translate.instant('Disconnect'))
+                    break
             }
         })
     }

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -55,7 +55,7 @@ export abstract class ConnectableTerminalTabComponent<P extends BaseTerminalProf
         if (this.frontend) {
             if (this.profile.behaviorOnSessionEnd === 'reconnect') {
                 this.reconnect()
-            } else if (this.profile.behaviorOnSessionEnd === 'keep' || this.profile.behaviorOnSessionEnd === 'auto' && !this.isSessionExplicitlyTerminated()) {
+            } else if (this.profile.behaviorOnSessionEnd === 'keep' || !this.doesTabShouldBeDestroyedOnSessionClosed()) {
                 this.offerReconnection()
             }
         }

--- a/tabby-terminal/src/hotkeys.ts
+++ b/tabby-terminal/src/hotkeys.ts
@@ -101,6 +101,10 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
             id: 'reconnect-tab',
             name: this.translate.instant('Reconnect current tab (Serial/Telnet/SSH)'),
         },
+        {
+            id: 'disconnect-tab',
+            name: this.translate.instant('Disconnect current tab (Serial/Telnet/SSH)'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -100,6 +100,15 @@ export class ReconnectContextMenu extends TabContextMenuItemProvider {
         if (tab instanceof ConnectableTerminalTabComponent) {
             return [
                 {
+                    label: this.translate.instant('Disconnect'),
+                    click: (): void => {
+                        setTimeout(() => {
+                            tab.disconnect()
+                            this.notifications.notice(this.translate.instant('Disconnect'))
+                        })
+                    },
+                },
+                {
                     label: this.translate.instant('Reconnect'),
                     click: (): void => {
                         setTimeout(() => {


### PR DESCRIPTION
Hi @Eugeny, I hope you're doing well.

I tried to add the feature asked in the issue #6518. This PR adds a hotkey `disconnect-tab` and a `Disconnect` item in the tab context menu.
I also tried to make this feature fits well with the configurable behavior on session end. Actually, disconnecting the current tab overrides the selected behavior :
- `keep` -> no effect, offer reconnection
- `close` & `auto` -> keep the tab open and offer reconnection

What is your opinion on this ? Do you think it would be more appropriate to create two distinct options if the tab behavior is `close` ? (`Disconnect` and `Disconnect & keep tab open` for example)

Feel free to ask if any changes are needed :)

Resolve #6518 