### PR TITLE
Update settingsTabBody.component.ts

### DIFF
--- a/tabby-settings/src/components/settingsTabBody.component.ts
+++ b/tabby-settings/src/components/settingsTabBody.component.ts
@@ -9,7 +9,7 @@ import { SettingsTabProvider } from '../api'
         :host {
             display: block;
             padding-bottom: 20px;
-            max-width: 500px;
+            max-width: 600px;
         }
     `],
 })


### PR DESCRIPTION
Increase the value of max-width to avoid shadowing the font size in the Settings (Settings - Appearance - Font).

The font size is 14, but only 1 can be seen.
![图片](https://github.com/Eugeny/tabby/assets/13901864/75d9506a-8ae4-43c3-9168-540ba4080a93)
![图片](https://github.com/Eugeny/tabby/assets/13901864/844ab747-7ca9-4fb1-b0a9-1765afb16a02)

After increase the max-width to 600px.
![图片](https://github.com/Eugeny/tabby/assets/13901864/1016115d-e819-4709-8801-22d3a23e7a94)

The reason for choosing 600px is that I saw that the max-width of div below is 600px.
![图片](https://github.com/Eugeny/tabby/assets/13901864/79917e2b-2887-499d-98dc-4d9487183dea)

