### PR TITLE
Cross Compile linux armhf/arm64 artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,9 +202,8 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           DEBIAN_FRONTEND=noninteractive apt-get -yq install nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          env 
-          # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
-          # export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
+          export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,14 +175,12 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
-          echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
-          echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ buster /build-chroot/
           wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
           tar -xJf node-v18.16.0-linux-x64.tar.xz
           sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
-          description=Ubuntu 18.04 Build chroot
+          description=Debian Buster Build chroot
           type=directory
           directory=/build-chroot
           root-groups=root,sudo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,12 +175,13 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ buster /build-chroot/
-          wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
-          tar -xJf node-v18.16.0-linux-x64.tar.xz
-          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
+          echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
+          curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
+          echo 'deb http://deb.nodesource.com/node_16.x bionic main' | sudo tee /build-chroot/etc/apt/sources.list.d/nodesource.list >/dev/null
           echo "[build-chroot]
-          description=Debian Buster Build chroot
+          description=Ubuntu 18.04 Build chroot
           type=directory
           directory=/build-chroot
           root-groups=root,sudo
@@ -193,13 +194,15 @@ jobs:
 
     - name: Install deps and CrossBuild ${{matrix.build-arch}}
       run: |
-          sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y &&
-          dpkg --add-architecture ${{matrix.arch}} &&
-          apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}} &&
-          npm i -g yarn && 
-          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}} &&
-          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}} &&
-          yarn --network-timeout 1000000 --arch=${{matrix.arch}} &&
+          sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
+          dpkg --add-architecture ${{matrix.arch}}
+          apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
+          npm i -g yarn node-pregyp 
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
+          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          ls ./node_modules || echo node_modules not present 
+          yarn --network-timeout 1000000 --arch=${{matrix.arch}}
+          ls ./node_modules
           yarn run build"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,8 @@ jobs:
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
-          npm i -g yarn node-pre-gyp node-pty
+          npm i -g yarn node-pre-gyp
+          npm i node-pty
           cd ./app/node_modules/node-pty 
           node-gyp configure build
           cd ../../.. 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,9 +178,9 @@ jobs:
           sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
-          wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -O node-v18.16.0.tar.xz
-          tar -xJf node-v18.16.0.tar.xz
-          sudo cp node-v18.16.0/* /build-chroot/usr/local/ -R
+          wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
+          tar -xJf node-v18.16.0-linux-x64.tar.xz
+          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
           description=Ubuntu 18.04 Build chroot
           type=directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-minimal,python3-minimal,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
@@ -187,7 +187,6 @@ jobs:
           root-groups=root,sudo
           profile=buildd
           personality=linux
-          preserve-environment=false
           union-type=overlay" | sudo tee /etc/schroot/chroot.d/build-chroot.pref >/dev/null 
           echo "/home           /home           none    rw,bind         0       0" | sudo tee -a /etc/schroot/buildd/fstab >/dev/null
       if: matrix.build-arch != 'x64'
@@ -197,7 +196,6 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          ln -s /usr/bin/python3 /usr/bin/python
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,8 @@ jobs:
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           sudo ln -s /usr/bin/python3 /usr/bin/python
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
+          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},pkg-config-${{matrix.triplet%-}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},pkg-config-${triplet%-},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
@@ -192,6 +192,8 @@ jobs:
           preserve-environment=true
           union-type=overlay" | sudo tee /etc/schroot/chroot.d/build-chroot.pref >/dev/null 
           echo "/home           /home           none    rw,bind         0       0" | sudo tee -a /etc/schroot/buildd/fstab >/dev/null
+      env: 
+        triplet: ${{matrix.triplet}}
       if: matrix.build-arch != 'x64'
 
     - name: Install deps and CrossBuild ${{matrix.build-arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,8 +179,8 @@ jobs:
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -o node.tar.xz
-          tar -xJf node-v18.16.0-linux-x64.tar.xz
-          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
+          tar -xJf node.tar.xz
+          sudo cp node/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
           description=Ubuntu 18.04 Build chroot
           type=directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,12 +197,13 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          npm i -g yarn node-pre-gyp 
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
-          ls ./node_modules || echo node_modules not present 
+          npm i -g yarn node-pre-gyp node-pty
+          cd ./app/node_modules/node-pty 
+          node-gyp configure build
+          cd ../../.. 
           yarn --network-timeout 1000000 --arch=${{matrix.arch}}
-          ls ./node_modules
           yarn run build"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,11 +134,9 @@ jobs:
         include:
           - build-arch: x64
           - build-arch: arm64
-            npm_arch: arm64
             arch: arm64
             triplet: aarch64-linux-gnu-
-          - build-arch: armv7l
-            npm_arch: arm
+          - build-arch: arm 
             arch: armhf
             triplet: arm-linux-gnueabihf-
     env:
@@ -200,9 +198,9 @@ jobs:
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
-          export npm_config_arch=${{matrix.npm_arch}} npm_config_target_arch=${{matrix.build-arch}}
+          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
-          yarn --network-timeout 1000000 --arch=${{matrix.npm_arch}} --target_arch=${{matrix.build-arch}}
+          yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       run: |
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
-          DEBIAN_FRONTEND=noninteractive apt-get -yq install nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
+          DEBIAN_FRONTEND=noninteractive apt-get -yqq install nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
           export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,11 +200,11 @@ jobs:
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn node-pre-gyp
-          npm i node-pty
+          yarn --network-timeout 1000000 --arch=${{matrix.arch}} --mode skip-build
           cd ./app/node_modules/node-pty 
-          node-gyp configure build
-          cd ../../.. 
-          yarn --network-timeout 1000000 --arch=${{matrix.arch}}
+          npx node-gyp configure build
+          cd ../../..
+          yarn rebuild
           yarn run build"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,134 +1,134 @@
 name: Package-Build
 on: [push, pull_request]
 jobs:
-#   Lint:
-#     runs-on: macos-11
+  Lint:
+    runs-on: macos-11
 
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v3
-#       with:
-#         fetch-depth: 0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-#     - name: Installing Node
-#       uses: actions/setup-node@v3.6.0
-#       with:
-#         node-version: 16
+    - name: Installing Node
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version: 16
 
-#     - name: Install deps
-#       run: |
-#         npm i -g yarn@1.19.1
-#         cd app
-#         yarn
-#         cd ..
-#         rm app/node_modules/.yarn-integrity
-#         yarn
+    - name: Install deps
+      run: |
+        npm i -g yarn@1.19.1
+        cd app
+        yarn
+        cd ..
+        rm app/node_modules/.yarn-integrity
+        yarn
 
-#     - name: Build typings
-#       run: yarn run build:typings
+    - name: Build typings
+      run: yarn run build:typings
 
-#     - name: Lint
-#       run: yarn run lint
+    - name: Lint
+      run: yarn run lint
 
-#   macOS-Build:
-#     runs-on: macos-11
-# #     needs: Lint
-#     strategy:
-#       matrix:
-#         include:
-#           - arch: x86_64
-#           - arch: arm64
-#       fail-fast: false
+  macOS-Build:
+    runs-on: macos-11
+    needs: Lint
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+          - arch: arm64
+      fail-fast: false
 
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v3
-#       with:
-#         fetch-depth: 0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-#     - name: Installing Node
-#       uses: actions/setup-node@v3.6.0
-#       with:
-#         node-version: 16
+    - name: Installing Node
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version: 16
 
-#     - name: Install deps
-#       run: |
-#         sudo npm i -g yarn@1.22.1
-#         yarn --network-timeout 1000000
-#       env:
-#         ARCH: ${{matrix.arch}}
+    - name: Install deps
+      run: |
+        sudo npm i -g yarn@1.22.1
+        yarn --network-timeout 1000000
+      env:
+        ARCH: ${{matrix.arch}}
 
-#     - name: Fix cross build
-#       run: |
-#         rm -rf app/node_modules/cpu-features
-#         rm -rf app/node_modules/ssh2/crypto/build
-#       if: matrix.arch == 'arm64'
+    - name: Fix cross build
+      run: |
+        rm -rf app/node_modules/cpu-features
+        rm -rf app/node_modules/ssh2/crypto/build
+      if: matrix.arch == 'arm64'
 
-#     - name: Webpack
-#       run: yarn run build
+    - name: Webpack
+      run: yarn run build
 
-#     - name: Prepackage plugins
-#       run: scripts/prepackage-plugins.mjs
-#       env:
-#         ARCH: ${{matrix.arch}}
+    - name: Prepackage plugins
+      run: scripts/prepackage-plugins.mjs
+      env:
+        ARCH: ${{matrix.arch}}
 
-#     - run: sed -i '' 's/updateInfo = await/\/\/updateInfo = await/g' node_modules/app-builder-lib/out/targets/ArchiveTarget.js
+    - run: sed -i '' 's/updateInfo = await/\/\/updateInfo = await/g' node_modules/app-builder-lib/out/targets/ArchiveTarget.js
 
-#     # Work around electron-builder beta bug
-#     - run: ln -s ../../node_modules/electron app/node_modules
+    # Work around electron-builder beta bug
+    - run: ln -s ../../node_modules/electron app/node_modules
 
-#     - name: Build and sign packages
-#       run: scripts/build-macos.mjs
-#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
-#       env:
-#         ARCH: ${{matrix.arch}}
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-#         CSC_LINK: ${{ secrets.CSC_LINK }}
-#         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-#         APPSTORE_USERNAME: ${{ secrets.APPSTORE_USERNAME }}
-#         APPSTORE_PASSWORD: ${{ secrets.APPSTORE_PASSWORD }}
-#         USE_HARD_LINKS: false
-#         # DEBUG: electron-builder,electron-builder:*
+    - name: Build and sign packages
+      run: scripts/build-macos.mjs
+      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+      env:
+        ARCH: ${{matrix.arch}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+        CSC_LINK: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        APPSTORE_USERNAME: ${{ secrets.APPSTORE_USERNAME }}
+        APPSTORE_PASSWORD: ${{ secrets.APPSTORE_PASSWORD }}
+        USE_HARD_LINKS: false
+        # DEBUG: electron-builder,electron-builder:*
 
-#     - name: Build packages without signing
-#       run: scripts/build-macos.mjs
-#       if: "! (github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
-#       env:
-#         ARCH: ${{matrix.arch}}
-#         # DEBUG: electron-builder,electron-builder:*
+    - name: Build packages without signing
+      run: scripts/build-macos.mjs
+      if: "! (github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
+      env:
+        ARCH: ${{matrix.arch}}
+        # DEBUG: electron-builder,electron-builder:*
 
-#     - name: Upload symbols
-#       run: |
-#         sudo npm install -g @sentry/cli --unsafe-perm
-#         ./scripts/sentry-upload.mjs
-#       env:
-#         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-#         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+    - name: Upload symbols
+      run: |
+        sudo npm install -g @sentry/cli --unsafe-perm
+        ./scripts/sentry-upload.mjs
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-#     - name: Package artifacts
-#       run: |
-#         mkdir artifact-pkg
-#         mv dist/*.pkg artifact-pkg/
-#         mkdir artifact-zip
-#         mv dist/*.zip artifact-zip/
+    - name: Package artifacts
+      run: |
+        mkdir artifact-pkg
+        mv dist/*.pkg artifact-pkg/
+        mkdir artifact-zip
+        mv dist/*.zip artifact-zip/
 
-#     - uses: actions/upload-artifact@master
-#       name: Upload PKG
-#       with:
-#         name: macOS .pkg (${{matrix.arch}})
-#         path: artifact-pkg
+    - uses: actions/upload-artifact@master
+      name: Upload PKG
+      with:
+        name: macOS .pkg (${{matrix.arch}})
+        path: artifact-pkg
 
-#     - uses: actions/upload-artifact@master
-#       name: Upload ZIP
-#       with:
-#         name: macOS .zip (${{matrix.arch}})
-#         path: artifact-zip
+    - uses: actions/upload-artifact@master
+      name: Upload ZIP
+      with:
+        name: macOS .zip (${{matrix.arch}})
+        path: artifact-zip
 
   Linux-Build:
     runs-on: ubuntu-20.04
-#     needs: Lint
+    needs: Lint
     strategy:
       matrix:
         include:
@@ -268,9 +268,9 @@ jobs:
 #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
 #         USE_HARD_LINKS: false
-#       if: matrix.build-arch == 'armv7l' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
+#       if: matrix.build-arch == 'arm' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
 
-    - name: Upload symbols (x64)
+    - name: Upload symbols (x64 only)
       run: |
         sudo npm install -g @sentry/cli --unsafe-perm
         ./scripts/sentry-upload.mjs
@@ -280,124 +280,124 @@ jobs:
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-#     - name: Upload packages to packagecloud.io
-#       uses: Eugeny/packagecloud-action@main
-#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-#       env:
-#         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-#       with:
-#         repo: 'eugeny/tabby'
-#         dir: 'dist'
+    - name: Upload packages to packagecloud.io
+      uses: Eugeny/packagecloud-action@main
+      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      env:
+        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      with:
+        repo: 'eugeny/tabby'
+        dir: 'dist'
 
     - uses: actions/upload-artifact@master
-      name: Upload DEB (${{matrix.build-arch}})
+      name: Upload DEB (${{matrix.arch}})
       with:
-        name: Linux DEB (${{matrix.build-arch}})
+        name: Linux DEB (${{matrix.arch}})
         path: dist/*.deb
 
     - uses: actions/upload-artifact@master
-      name: Upload RPM (${{matrix.build-arch}})
+      name: Upload RPM (${{matrix.arch}})
       with:
-        name: Linux RPM (${{matrix.build-arch}})
+        name: Linux RPM (${{matrix.arch}})
         path: dist/*.rpm
 
     - uses: actions/upload-artifact@master
-      name: Upload Pacman Package (${{matrix.build-arch}})
+      name: Upload Pacman Package (${{matrix.arch}})
       with:
-        name: Linux Pacman (${{matrix.build-arch}})
+        name: Linux Pacman (${{matrix.arch}})
         path: dist/*.pacman
 
     - uses: actions/upload-artifact@master
-      name: Upload Linux tarball (${{matrix.build-arch}})
+      name: Upload Linux tarball (${{matrix.arch}})
       with:
-        name: Linux tarball (${{matrix.build-arch}})
+        name: Linux tarball (${{matrix.arch}})
         path: dist/*.tar.gz
 
     - uses: actions/upload-artifact@master
-      name: Upload web tarball
+      name: Upload web tarball (x64 only)
       with:
         name: Web tarball
         path: tabby-web.tar.gz
       if: matrix.build-arch == 'x64'
 
 
-#   Windows-Build:
-#     runs-on: windows-2022
-# #     needs: Lint
-#     strategy:
-#       matrix:
-#         include:
-#           - arch: x64
-#           - arch: arm64
-#       fail-fast: false
+  Windows-Build:
+    runs-on: windows-2022
+    needs: Lint
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+          - arch: arm64
+      fail-fast: false
 
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v3
-#       with:
-#         fetch-depth: 0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-#     - name: Installing Node
-#       uses: actions/setup-node@v3.6.0
-#       with:
-#         node-version: 16
+    - name: Installing Node
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version: 16
 
-#     - name: Update node-gyp
-#       run: |
-#         npm install --global node-gyp@8.4.1
-#         npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+    - name: Update node-gyp
+      run: |
+        npm install --global node-gyp@8.4.1
+        npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
-#     - name: Build
-#       shell: powershell
-#       run: |
-#         npm i -g yarn@1.19.1
-#         yarn --network-timeout 1000000
-#         yarn run build
-#         node scripts/prepackage-plugins.mjs
-#       env:
-#         ARCH: ${{matrix.arch}}
+    - name: Build
+      shell: powershell
+      run: |
+        npm i -g yarn@1.19.1
+        yarn --network-timeout 1000000
+        yarn run build
+        node scripts/prepackage-plugins.mjs
+      env:
+        ARCH: ${{matrix.arch}}
 
-#     - name: Build and sign packages
-#       run: node scripts/build-windows.mjs
-#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
-#       env:
-#         ARCH: ${{matrix.arch}}
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-#         WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-#         WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-#         DEBUG: electron-builder,electron-builder:*
+    - name: Build and sign packages
+      run: node scripts/build-windows.mjs
+      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+      env:
+        ARCH: ${{matrix.arch}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+        WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+        WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        DEBUG: electron-builder,electron-builder:*
 
-#     - name: Build packages without signing
-#       run: node scripts/build-windows.mjs
-#       if: "!(github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
-#       env:
-#         ARCH: ${{matrix.arch}}
+    - name: Build packages without signing
+      run: node scripts/build-windows.mjs
+      if: "!(github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
+      env:
+        ARCH: ${{matrix.arch}}
 
-#     - name: Upload symbols
-#       run: |
-#         npm install @sentry/cli
-#         node scripts/sentry-upload.mjs
-#       env:
-#         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-#         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+    - name: Upload symbols
+      run: |
+        npm install @sentry/cli
+        node scripts/sentry-upload.mjs
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-#     - name: Package artifacts
-#       run: |
-#         mkdir artifact-setup
-#         mv dist/*-setup-*.exe artifact-setup/
-#         mkdir artifact-portable
-#         mv dist/*-portable-*.zip artifact-portable/
+    - name: Package artifacts
+      run: |
+        mkdir artifact-setup
+        mv dist/*-setup-*.exe artifact-setup/
+        mkdir artifact-portable
+        mv dist/*-portable-*.zip artifact-portable/
 
-#     - uses: actions/upload-artifact@master
-#       name: Upload installer
-#       with:
-#         name: Windows installer (${{matrix.arch}})
-#         path: artifact-setup
+    - uses: actions/upload-artifact@master
+      name: Upload installer
+      with:
+        name: Windows installer (${{matrix.arch}})
+        path: artifact-setup
 
-#     - uses: actions/upload-artifact@master
-#       name: Upload portable build
-#       with:
-#         name: Windows portable build (${{matrix.arch}})
-#         path: artifact-portable
+    - uses: actions/upload-artifact@master
+      name: Upload portable build
+      with:
+        name: Windows portable build (${{matrix.arch}})
+        path: artifact-portable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,6 @@ jobs:
     env:
       CC: ${{matrix.triplet}}gcc
       CXX: ${{matrix.triplet}}g++
-      LD: ${{matrix.triplet}}ld
-      PKG_CONFIG: ${{matrix.triplet}}pkg-config
       ARCH: ${{matrix.build-arch}}
       npm_config_arch: ${{matrix.build-arch}}
       npm_config_target_arch: ${{matrix.build-arch}}
@@ -169,16 +167,12 @@ jobs:
         npm i -g yarn
         yarn --network-timeout 1000000 --arch=${{matrix.arch}}
       if: matrix.build-arch == 'x64'
-    
-    - name: Webpack (x64)
-      run: yarn run build
-      if: matrix.build-arch == 'x64'
       
     - name: Setup Crossbuild (${{matrix.build-arch}})
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},pkg-config-${triplet%-},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
@@ -190,36 +184,38 @@ jobs:
           root-groups=root,sudo
           profile=buildd
           personality=linux
-          preserve-environment=true
           union-type=overlay" | sudo tee /etc/schroot/chroot.d/build-chroot.pref >/dev/null 
           echo "/home           /home           none    rw,bind         0       0" | sudo tee -a /etc/schroot/buildd/fstab >/dev/null
+
+      if: matrix.build-arch != 'x64'
+
+    - name: Install node_modules & CrossBuild native modules for ${{matrix.arch}}
+      run: |
+          sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
+          dpkg --add-architecture ${{matrix.arch}}
+          apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ LD=${{matrix.triplet}}ld PKG_CONFIG_PATH=/usr/lib/${triplet%-}/pkfconfig/
+          export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          npm i -g yarn
+          yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
       env: 
         triplet: ${{matrix.triplet}}
       if: matrix.build-arch != 'x64'
 
-    - name: Install deps and CrossBuild ${{matrix.build-arch}}
-      run: |
-          sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
-          dpkg --add-architecture ${{matrix.arch}}
-          DEBIAN_FRONTEND=noninteractive apt-get -yqq install nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
-          export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
-          npm i -g yarn
-          yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
-          yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
-      if: matrix.build-arch != 'x64'
+    - name: Webpack (${{matrix.arch}})
+      run: yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
 
-    - name: Prepackage plugins (${{matrix.build-arch}})
+    - name: Prepackage plugins (${{matrix.arch}})
       run: scripts/prepackage-plugins.mjs
       
-    - name: Build packages (${{matrix.build-arch}})
+    - name: Build packages (${{matrix.arch}})
       run: scripts/build-linux.mjs
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
         USE_HARD_LINKS: false
         # DEBUG: electron-builder,electron-builder:*
-
+        
     - name: Build web resources
       run: zsh -c 'tar czf tabby-web.tar.gz (tabby-*|web)/dist'
       if: matrix.build-arch == 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,15 +158,15 @@ jobs:
       with:
         node-version: 18
 
-    - name: Install deps (x64)
+    - name: Install deps (amd64)
       run: |
         sudo apt-get update
         sudo apt-get install libarchive-tools zsh 
         
-    - name: Install npm_modules (x64)
+    - name: Install npm_modules (amd64)
       run: |
         npm i -g yarn
-        yarn --network-timeout 1000000 --arch=${{matrix.arch}}
+        yarn --network-timeout 1000000
       if: matrix.build-arch == 'x64'
       
     - name: Setup Crossbuild (${{matrix.arch}})
@@ -270,7 +270,7 @@ jobs:
 #         USE_HARD_LINKS: false
 #       if: matrix.build-arch == 'arm' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
 
-    - name: Upload symbols (x64 only)
+    - name: Upload symbols (amd64 only)
       run: |
         sudo npm install -g @sentry/cli --unsafe-perm
         ./scripts/sentry-upload.mjs
@@ -314,7 +314,7 @@ jobs:
         path: dist/*.tar.gz
 
     - uses: actions/upload-artifact@master
-      name: Upload web tarball (x64 only)
+      name: Upload web tarball (amd64 only)
       with:
         name: Web tarball
         path: tabby-web.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,11 @@ jobs:
         include:
           - build-arch: x64
           - build-arch: arm64
+            npm_arch: arm64
             arch: arm64
             triplet: aarch64-linux-gnu-
           - build-arch: armv7l
+            npm_arch: arm
             arch: armhf
             triplet: arm-linux-gnueabihf-
     env:
@@ -198,15 +200,9 @@ jobs:
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
-          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          export npm_config_arch=${{matrix.npm_arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
-          yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
-          cd ./app/node_modules/node-pty 
-          npx node-gyp configure build
-          cd ../../
-          echo Rebuilding node-pty
-          npm rebuild node-pty --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
-          cd ..
+          yarn --network-timeout 1000000 --arch=${{matrix.npm_arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,8 @@ jobs:
           cd ./app/node_modules/node-pty 
           npx node-gyp configure build
           cd ../../
-          npm rebuild node-pty
+          echo Rebuilding node-pty
+          yarn rebuild node-pty
           cd ..
           yarn run build"
       if: matrix.build-arch != 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-minimal,python3-minimal,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          sudo ln -s /usr/bin/python3 /usr/bin/python
+          ln -s /usr/bin/python3 /usr/bin/python
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn node-pre-gyp
-          yarn --network-timeout 1000000 --arch=${{matrix.arch}} --mode skip-build
+          yarn --network-timeout 1000000 --arch=${{matrix.arch}}
           cd ./app/node_modules/node-pty 
           npx node-gyp configure build
           cd ../../..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,12 +194,15 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ LD=${{matrix.triplet}}ld PKG_CONFIG_PATH=/usr/lib/${triplet%-}/pkfconfig/
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ LD=${{matrix.triplet}}ld 
+          if [[ ${{matrix.arch}} == 'arm64' ]]; then
+            export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/aarch64-linux-gnu/pkgconfig/
+          elif [[ ${{matrix.arch}} == 'armhf' ]]; then
+            export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/arm-linux-gnueabihf/pkgconfig/
+          fi
           export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
-      env: 
-        triplet: ${{matrix.triplet}}
       if: matrix.build-arch != 'x64'
 
     - name: Webpack (${{matrix.arch}})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
     env:
       CC: ${{matrix.triplet}}gcc
       CXX: ${{matrix.triplet}}g++
-      PKG_CONFIG: ${{matrix.triplet))pkg-config
+      PKG_CONFIG: ${{matrix.triplet}}pkg-config
       ARCH: ${{matrix.build-arch}}
       npm_config_arch: ${{matrix.build-arch}}
       npm_config_target_arch: ${{matrix.build-arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,173 +1,214 @@
 name: Package-Build
 on: [push, pull_request]
 jobs:
-  Lint:
-    runs-on: macos-11
+#   Lint:
+#     runs-on: macos-11
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@v3
+#       with:
+#         fetch-depth: 0
 
-    - name: Installing Node
-      uses: actions/setup-node@v3.6.0
-      with:
-        node-version: 16
+#     - name: Installing Node
+#       uses: actions/setup-node@v3.6.0
+#       with:
+#         node-version: 16
 
-    - name: Install deps
-      run: |
-        npm i -g yarn@1.19.1
-        cd app
-        yarn
-        cd ..
-        rm app/node_modules/.yarn-integrity
-        yarn
+#     - name: Install deps
+#       run: |
+#         npm i -g yarn@1.19.1
+#         cd app
+#         yarn
+#         cd ..
+#         rm app/node_modules/.yarn-integrity
+#         yarn
 
-    - name: Build typings
-      run: yarn run build:typings
+#     - name: Build typings
+#       run: yarn run build:typings
 
-    - name: Lint
-      run: yarn run lint
+#     - name: Lint
+#       run: yarn run lint
 
-  macOS-Build:
-    runs-on: macos-11
-    needs: Lint
-    strategy:
-      matrix:
-        include:
-          - arch: x86_64
-          - arch: arm64
-      fail-fast: false
+#   macOS-Build:
+#     runs-on: macos-11
+# #     needs: Lint
+#     strategy:
+#       matrix:
+#         include:
+#           - arch: x86_64
+#           - arch: arm64
+#       fail-fast: false
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@v3
+#       with:
+#         fetch-depth: 0
 
-    - name: Installing Node
-      uses: actions/setup-node@v3.6.0
-      with:
-        node-version: 16
+#     - name: Installing Node
+#       uses: actions/setup-node@v3.6.0
+#       with:
+#         node-version: 16
 
-    - name: Install deps
-      run: |
-        sudo npm i -g yarn@1.22.1
-        yarn --network-timeout 1000000
-      env:
-        ARCH: ${{matrix.arch}}
+#     - name: Install deps
+#       run: |
+#         sudo npm i -g yarn@1.22.1
+#         yarn --network-timeout 1000000
+#       env:
+#         ARCH: ${{matrix.arch}}
 
-    - name: Fix cross build
-      run: |
-        rm -rf app/node_modules/cpu-features
-        rm -rf app/node_modules/ssh2/crypto/build
-      if: matrix.arch == 'arm64'
+#     - name: Fix cross build
+#       run: |
+#         rm -rf app/node_modules/cpu-features
+#         rm -rf app/node_modules/ssh2/crypto/build
+#       if: matrix.arch == 'arm64'
 
-    - name: Webpack
-      run: yarn run build
+#     - name: Webpack
+#       run: yarn run build
 
-    - name: Prepackage plugins
-      run: scripts/prepackage-plugins.mjs
-      env:
-        ARCH: ${{matrix.arch}}
+#     - name: Prepackage plugins
+#       run: scripts/prepackage-plugins.mjs
+#       env:
+#         ARCH: ${{matrix.arch}}
 
-    - run: sed -i '' 's/updateInfo = await/\/\/updateInfo = await/g' node_modules/app-builder-lib/out/targets/ArchiveTarget.js
+#     - run: sed -i '' 's/updateInfo = await/\/\/updateInfo = await/g' node_modules/app-builder-lib/out/targets/ArchiveTarget.js
 
-    # Work around electron-builder beta bug
-    - run: ln -s ../../node_modules/electron app/node_modules
+#     # Work around electron-builder beta bug
+#     - run: ln -s ../../node_modules/electron app/node_modules
 
-    - name: Build and sign packages
-      run: scripts/build-macos.mjs
-      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
-      env:
-        ARCH: ${{matrix.arch}}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-        CSC_LINK: ${{ secrets.CSC_LINK }}
-        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        APPSTORE_USERNAME: ${{ secrets.APPSTORE_USERNAME }}
-        APPSTORE_PASSWORD: ${{ secrets.APPSTORE_PASSWORD }}
-        USE_HARD_LINKS: false
-        # DEBUG: electron-builder,electron-builder:*
+#     - name: Build and sign packages
+#       run: scripts/build-macos.mjs
+#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+#       env:
+#         ARCH: ${{matrix.arch}}
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+#         CSC_LINK: ${{ secrets.CSC_LINK }}
+#         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+#         APPSTORE_USERNAME: ${{ secrets.APPSTORE_USERNAME }}
+#         APPSTORE_PASSWORD: ${{ secrets.APPSTORE_PASSWORD }}
+#         USE_HARD_LINKS: false
+#         # DEBUG: electron-builder,electron-builder:*
 
-    - name: Build packages without signing
-      run: scripts/build-macos.mjs
-      if: "! (github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
-      env:
-        ARCH: ${{matrix.arch}}
-        # DEBUG: electron-builder,electron-builder:*
+#     - name: Build packages without signing
+#       run: scripts/build-macos.mjs
+#       if: "! (github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
+#       env:
+#         ARCH: ${{matrix.arch}}
+#         # DEBUG: electron-builder,electron-builder:*
 
-    - name: Upload symbols
-      run: |
-        sudo npm install -g @sentry/cli --unsafe-perm
-        ./scripts/sentry-upload.mjs
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+#     - name: Upload symbols
+#       run: |
+#         sudo npm install -g @sentry/cli --unsafe-perm
+#         ./scripts/sentry-upload.mjs
+#       env:
+#         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+#         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-    - name: Package artifacts
-      run: |
-        mkdir artifact-pkg
-        mv dist/*.pkg artifact-pkg/
-        mkdir artifact-zip
-        mv dist/*.zip artifact-zip/
+#     - name: Package artifacts
+#       run: |
+#         mkdir artifact-pkg
+#         mv dist/*.pkg artifact-pkg/
+#         mkdir artifact-zip
+#         mv dist/*.zip artifact-zip/
 
-    - uses: actions/upload-artifact@master
-      name: Upload PKG
-      with:
-        name: macOS .pkg (${{matrix.arch}})
-        path: artifact-pkg
+#     - uses: actions/upload-artifact@master
+#       name: Upload PKG
+#       with:
+#         name: macOS .pkg (${{matrix.arch}})
+#         path: artifact-pkg
 
-    - uses: actions/upload-artifact@master
-      name: Upload ZIP
-      with:
-        name: macOS .zip (${{matrix.arch}})
-        path: artifact-zip
+#     - uses: actions/upload-artifact@master
+#       name: Upload ZIP
+#       with:
+#         name: macOS .zip (${{matrix.arch}})
+#         path: artifact-zip
 
   Linux-Build:
     runs-on: ubuntu-20.04
-    needs: Lint
+#     needs: Lint
     strategy:
       matrix:
-        build-arch: [ x64, arm64, armv7l ]
+        include:
+          - build-arch: x64
+          - build-arch: arm64
+            arch: arm64
+            triplet: aarch64-linux-gnu-
+#           - build-arch: armv7l
+#             arch: armhf
+#             triplet: arm-linux-gnueabihf-
+    env:
+      CC: ${{matrix.triplet}}-gcc
+      CXX: ${{matrix.triplet}}-g++
+      ARCH: ${{matrix.build-arch}}
+      npm_config_arch: ${{matrix.build-arch}}
+      npm_config_target_arch: ${{matrix.build-arch}}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    - name: Set up multiarch/qemu-user-static
-      run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      if: matrix.build-arch != 'x64'
-
-    - name: Install Node (x64)
+            
+    - name: Install Node
       uses: actions/setup-node@v3.6.0
       with:
         node-version: 16
-      if: matrix.build-arch == 'x64'
 
     - name: Install deps (x64)
       run: |
         sudo apt-get update
-        sudo apt-get install libarchive-tools zsh
+        sudo apt-get install libarchive-tools zsh 
+    - name: Install npm_modules (x64)
+      run: |
         npm i -g yarn
-        yarn --network-timeout 1000000
+        yarn --network-timeout 1000000 --arch=${{matrix.arch}}
       if: matrix.build-arch == 'x64'
-
+    
     - name: Webpack (x64)
       run: yarn run build
       if: matrix.build-arch == 'x64'
+      
+    - name: Setup Crossbuild (${{matrix.build-arch}})
+      run: |
+          sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
+          sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
+          echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
+          curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
+          echo 'deb http://deb.nodesource.com/node_16.x bionic main' | sudo tee /build-chroot/etc/apt/sources.list.d/nodesource.list >/dev/null
+          echo "[build-chroot]
+          description=Ubuntu 18.04 Build chroot
+          type=directory
+          directory=/build-chroot
+          root-groups=root,sudo
+          profile=buildd
+          personality=linux
+          preserve-environment=false
+          union-type=overlay" | sudo tee /etc/schroot/chroot.d/build-chroot.pref >/dev/null 
+          echo "/home           /home           none    rw,bind         0       0" | sudo tee -a /etc/schroot/buildd/fstab >/dev/null
+      if: matrix.build-arch != 'x64'
 
-    - name: Prepackage plugins (x64)
+    - name: Install deps and CrossBuild ${{matrix.build-arch}}
+      run: |
+          sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y &&
+          dpkg --add-architecture ${{matrix.arch}} &&
+          apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}} &&
+          npm i -g yarn && 
+          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}} &&
+          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}} &&
+          yarn --network-timeout 1000000 --arch=${{matrix.arch}} &&
+          yarn run build"
+      if: matrix.build-arch != 'x64'
+
+    - name: Prepackage plugins (${{matrix.build-arch}})
       run: scripts/prepackage-plugins.mjs
-      if: ${{matrix.build-arch == 'x64'}}
-
-    - name: Build packages (x64)
+      
+    - name: Build packages (${{matrix.build-arch}})
       run: scripts/build-linux.mjs
-      if: ${{matrix.build-arch == 'x64'}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
@@ -178,54 +219,54 @@ jobs:
       run: zsh -c 'tar czf tabby-web.tar.gz (tabby-*|web)/dist'
       if: matrix.build-arch == 'x64'
 
-    - name: Install deps and Build (arm64)
-      uses: docker://multiarch/ubuntu-core:arm64-bionic
-      with:
-          args: >
-            bash -c
-            "apt update && apt install curl lsb-release gnupg -y &&
-            curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
-            apt install make build-essential git ruby libarchive-tools nodejs rpm libsecret-1-dev libfontconfig1-dev -y &&
-            git config --global --add safe.directory /github/workspace &&
-            gem install public_suffix -v 4.0.7 &&
-            gem install fpm --no-document &&
-            npm i -g yarn &&
-            cd /github/workspace &&
-            yarn --network-timeout 1000000 &&
-            yarn run build &&
-            scripts/prepackage-plugins.mjs &&
-            USE_SYSTEM_FPM=true scripts/build-linux.mjs"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-        USE_HARD_LINKS: false
-      if: matrix.build-arch == 'arm64' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
+#     - name: Install deps and Build (arm64)
+#       uses: docker://multiarch/ubuntu-core:arm64-bionic
+#       with:
+#           args: >
+#             bash -c
+#             "apt update && apt install curl lsb-release gnupg -y &&
+#             curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
+#             apt install make build-essential git ruby libarchive-tools nodejs rpm libsecret-1-dev libfontconfig1-dev -y &&
+#             git config --global --add safe.directory /github/workspace &&
+#             gem install public_suffix -v 4.0.7 &&
+#             gem install fpm --no-document &&
+#             npm i -g yarn &&
+#             cd /github/workspace &&
+#             yarn --network-timeout 1000000 &&
+#             yarn run build &&
+#             scripts/prepackage-plugins.mjs &&
+#             USE_SYSTEM_FPM=true scripts/build-linux.mjs"
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+#         USE_HARD_LINKS: false
+#       if: matrix.build-arch == 'arm64' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
 
-    - name: Install deps and Build (armv7l)
-      uses: docker://multiarch/ubuntu-core:armhf-bionic
-      with:
-          args: >
-            bash -c
-            "apt update && apt install curl lsb-release gnupg -y &&
-            curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
-            apt install make build-essential git ruby libarchive-tools nodejs rpm libsecret-1-dev libfontconfig1-dev -y &&
-            git config --global --add safe.directory /github/workspace &&
-            gem install public_suffix -v 4.0.7 &&
-            gem install fpm --no-document &&
-            npm i -g yarn &&
-            cd /github/workspace &&
-            sed -i '/    \"electron\":/c\    \"electron\": \"17.0.0\",' package.json &&
-            yarn --network-timeout 1000000 &&
-            yarn run build &&
-            scripts/prepackage-plugins.mjs &&
-            USE_SYSTEM_FPM=true scripts/build-linux.mjs"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-        USE_HARD_LINKS: false
-      if: matrix.build-arch == 'armv7l' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
+#     - name: Install deps and Build (armv7l)
+#       uses: docker://multiarch/ubuntu-core:armhf-bionic
+#       with:
+#           args: >
+#             bash -c
+#             "apt update && apt install curl lsb-release gnupg -y &&
+#             curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
+#             apt install make build-essential git ruby libarchive-tools nodejs rpm libsecret-1-dev libfontconfig1-dev -y &&
+#             git config --global --add safe.directory /github/workspace &&
+#             gem install public_suffix -v 4.0.7 &&
+#             gem install fpm --no-document &&
+#             npm i -g yarn &&
+#             cd /github/workspace &&
+#             sed -i '/    \"electron\":/c\    \"electron\": \"17.0.0\",' package.json &&
+#             yarn --network-timeout 1000000 &&
+#             yarn run build &&
+#             scripts/prepackage-plugins.mjs &&
+#             USE_SYSTEM_FPM=true scripts/build-linux.mjs"
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+#         USE_HARD_LINKS: false
+#       if: matrix.build-arch == 'armv7l' && github.repository == 'Eugeny/tabby' && startsWith(github.ref, 'refs/tags')
 
-    - name: Upload symbols
+    - name: Upload symbols (x64)
       run: |
         sudo npm install -g @sentry/cli --unsafe-perm
         ./scripts/sentry-upload.mjs
@@ -235,35 +276,35 @@ jobs:
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-    - name: Upload packages to packagecloud.io
-      uses: Eugeny/packagecloud-action@main
-      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      env:
-        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-      with:
-        repo: 'eugeny/tabby'
-        dir: 'dist'
+#     - name: Upload packages to packagecloud.io
+#       uses: Eugeny/packagecloud-action@main
+#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+#       env:
+#         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+#       with:
+#         repo: 'eugeny/tabby'
+#         dir: 'dist'
 
     - uses: actions/upload-artifact@master
-      name: Upload DEB
+      name: Upload DEB (${{matrix.build-arch}})
       with:
         name: Linux DEB (${{matrix.build-arch}})
         path: dist/*.deb
 
     - uses: actions/upload-artifact@master
-      name: Upload RPM
+      name: Upload RPM (${{matrix.build-arch}})
       with:
         name: Linux RPM (${{matrix.build-arch}})
         path: dist/*.rpm
 
     - uses: actions/upload-artifact@master
-      name: Upload Pacman Package
+      name: Upload Pacman Package (${{matrix.build-arch}})
       with:
         name: Linux Pacman (${{matrix.build-arch}})
         path: dist/*.pacman
 
     - uses: actions/upload-artifact@master
-      name: Upload Linux tarball
+      name: Upload Linux tarball (${{matrix.build-arch}})
       with:
         name: Linux tarball (${{matrix.build-arch}})
         path: dist/*.tar.gz
@@ -276,83 +317,83 @@ jobs:
       if: matrix.build-arch == 'x64'
 
 
-  Windows-Build:
-    runs-on: windows-2022
-    needs: Lint
-    strategy:
-      matrix:
-        include:
-          - arch: x64
-          - arch: arm64
-      fail-fast: false
+#   Windows-Build:
+#     runs-on: windows-2022
+# #     needs: Lint
+#     strategy:
+#       matrix:
+#         include:
+#           - arch: x64
+#           - arch: arm64
+#       fail-fast: false
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@v3
+#       with:
+#         fetch-depth: 0
 
-    - name: Installing Node
-      uses: actions/setup-node@v3.6.0
-      with:
-        node-version: 16
+#     - name: Installing Node
+#       uses: actions/setup-node@v3.6.0
+#       with:
+#         node-version: 16
 
-    - name: Update node-gyp
-      run: |
-        npm install --global node-gyp@8.4.1
-        npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+#     - name: Update node-gyp
+#       run: |
+#         npm install --global node-gyp@8.4.1
+#         npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
-    - name: Build
-      shell: powershell
-      run: |
-        npm i -g yarn@1.19.1
-        yarn --network-timeout 1000000
-        yarn run build
-        node scripts/prepackage-plugins.mjs
-      env:
-        ARCH: ${{matrix.arch}}
+#     - name: Build
+#       shell: powershell
+#       run: |
+#         npm i -g yarn@1.19.1
+#         yarn --network-timeout 1000000
+#         yarn run build
+#         node scripts/prepackage-plugins.mjs
+#       env:
+#         ARCH: ${{matrix.arch}}
 
-    - name: Build and sign packages
-      run: node scripts/build-windows.mjs
-      if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
-      env:
-        ARCH: ${{matrix.arch}}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
-        WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-        WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        DEBUG: electron-builder,electron-builder:*
+#     - name: Build and sign packages
+#       run: node scripts/build-windows.mjs
+#       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags'))
+#       env:
+#         ARCH: ${{matrix.arch}}
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
+#         WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+#         WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+#         DEBUG: electron-builder,electron-builder:*
 
-    - name: Build packages without signing
-      run: node scripts/build-windows.mjs
-      if: "!(github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
-      env:
-        ARCH: ${{matrix.arch}}
+#     - name: Build packages without signing
+#       run: node scripts/build-windows.mjs
+#       if: "!(github.repository == 'Eugeny/tabby' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')))"
+#       env:
+#         ARCH: ${{matrix.arch}}
 
-    - name: Upload symbols
-      run: |
-        npm install @sentry/cli
-        node scripts/sentry-upload.mjs
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+#     - name: Upload symbols
+#       run: |
+#         npm install @sentry/cli
+#         node scripts/sentry-upload.mjs
+#       env:
+#         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+#         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-    - name: Package artifacts
-      run: |
-        mkdir artifact-setup
-        mv dist/*-setup-*.exe artifact-setup/
-        mkdir artifact-portable
-        mv dist/*-portable-*.zip artifact-portable/
+#     - name: Package artifacts
+#       run: |
+#         mkdir artifact-setup
+#         mv dist/*-setup-*.exe artifact-setup/
+#         mkdir artifact-portable
+#         mv dist/*-portable-*.zip artifact-portable/
 
-    - uses: actions/upload-artifact@master
-      name: Upload installer
-      with:
-        name: Windows installer (${{matrix.arch}})
-        path: artifact-setup
+#     - uses: actions/upload-artifact@master
+#       name: Upload installer
+#       with:
+#         name: Windows installer (${{matrix.arch}})
+#         path: artifact-setup
 
-    - uses: actions/upload-artifact@master
-      name: Upload portable build
-      with:
-        name: Windows portable build (${{matrix.arch}})
-        path: artifact-portable
+#     - uses: actions/upload-artifact@master
+#       name: Upload portable build
+#       with:
+#         name: Windows portable build (${{matrix.arch}})
+#         path: artifact-portable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,9 +178,9 @@ jobs:
           sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
-          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -o node.tar.xz
-          tar -xJf node.tar.xz
-          sudo cp node/* /build-chroot/usr/local/ -R
+          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
+          tar -xJf node-v18.16.0-linux-x64.tar.xz
+          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
           description=Ubuntu 18.04 Build chroot
           type=directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,9 +178,9 @@ jobs:
           sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
-          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
-          tar -xJf node-v18.16.0-linux-x64.tar.xz
-          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
+          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -o node-v18.16.0.tar.xz
+          tar -xJf node-v18.16.0.tar.xz
+          sudo cp node-v18.16.0/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
           description=Ubuntu 18.04 Build chroot
           type=directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          npm i -g yarn node-pregyp 
+          npm i -g yarn node-pre-gyp 
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           ls ./node_modules || echo node_modules not present 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,8 +203,9 @@ jobs:
           yarn --network-timeout 1000000 --arch=${{matrix.arch}}
           cd ./app/node_modules/node-pty 
           npx node-gyp configure build
-          cd ../../..
-          yarn rebuild
+          cd ../../
+          npm rebuild node-pty
+          cd ..
           yarn run build"
       if: matrix.build-arch != 'x64'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,8 +201,8 @@ jobs:
       run: |
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
-          apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          env | grep -e CC -e CXX -e PKG_CONFIG -e LD -e ARCH -e npm_config_
+          DEBIAN_FRONTEND=noninteractive apt-get -yq install nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
+          env 
           # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
           # export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,8 +197,7 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
-          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          sudo ln -s /usr/bin/python3 /usr/bin/python
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,8 +140,9 @@ jobs:
             arch: armhf
             triplet: arm-linux-gnueabihf-
     env:
-      CC: ${{matrix.triplet}}-gcc
-      CXX: ${{matrix.triplet}}-g++
+      CC: ${{matrix.triplet}}gcc
+      CXX: ${{matrix.triplet}}g++
+      PKG_CONFIG: ${{matrix.triplet))pkg-config
       ARCH: ${{matrix.build-arch}}
       npm_config_arch: ${{matrix.build-arch}}
       npm_config_target_arch: ${{matrix.build-arch}}
@@ -161,6 +162,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libarchive-tools zsh 
+        
     - name: Install npm_modules (x64)
       run: |
         npm i -g yarn
@@ -175,7 +177,7 @@ jobs:
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
           sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},pkg-config-${{matrix.triplet%-}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
@@ -187,6 +189,7 @@ jobs:
           root-groups=root,sudo
           profile=buildd
           personality=linux
+          preserve-environment=true
           union-type=overlay" | sudo tee /etc/schroot/chroot.d/build-chroot.pref >/dev/null 
           echo "/home           /home           none    rw,bind         0       0" | sudo tee -a /etc/schroot/buildd/fstab >/dev/null
       if: matrix.build-arch != 'x64'
@@ -196,8 +199,8 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
-          export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
-          export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
+          # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config
+          # export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,7 @@ jobs:
       matrix:
         include:
           - build-arch: x64
+            arch: amd64
           - build-arch: arm64
             arch: arm64
             triplet: aarch64-linux-gnu-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
     env:
       CC: ${{matrix.triplet}}gcc
       CXX: ${{matrix.triplet}}g++
-      LD: ${{matrix.triplet))ld
+      LD: ${{matrix.triplet}}ld
       PKG_CONFIG: ${{matrix.triplet}}pkg-config
       ARCH: ${{matrix.build-arch}}
       npm_config_arch: ${{matrix.build-arch}}
@@ -203,7 +203,7 @@ jobs:
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           env | grep -e CC -e CXX -e PKG_CONFIG -e LD -e ARCH -e npm_config_
-          # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config
+          # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config LD= ${{matrix.triplet}}ld
           # export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn
           yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
     env:
       CC: ${{matrix.triplet}}gcc
       CXX: ${{matrix.triplet}}g++
+      LD: ${{matrix.triplet))ld
       PKG_CONFIG: ${{matrix.triplet}}pkg-config
       ARCH: ${{matrix.build-arch}}
       npm_config_arch: ${{matrix.build-arch}}
@@ -201,6 +202,7 @@ jobs:
           sudo schroot -c build-chroot -u root -- bash -c "apt-get update -y
           dpkg --add-architecture ${{matrix.arch}}
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
+          env | grep -e CC -e CXX -e PKG_CONFIG -e LD -e ARCH -e npm_config_
           # export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ PKG_BUILD=${{matrix.triplet}}pkg-config
           # export ARCH=${{matrix.build-arch}} npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
           npm i -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
           sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
-          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -o node-v18.16.0.tar.xz
+          wget https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -O node-v18.16.0.tar.xz
           tar -xJf node-v18.16.0.tar.xz
           sudo cp node-v18.16.0/* /build-chroot/usr/local/ -R
           echo "[build-chroot]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,11 +168,10 @@ jobs:
         yarn --network-timeout 1000000 --arch=${{matrix.arch}}
       if: matrix.build-arch == 'x64'
       
-    - name: Setup Crossbuild (${{matrix.build-arch}})
+    - name: Setup Crossbuild (${{matrix.arch}})
       run: |
           sudo apt-get update -y && sudo apt-get install schroot sbuild debootstrap -y
-          sudo mkdir  -p /tmp/debootstrap-cache /build-chroot
-          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
+          sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},python-dev,python3-dev,libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
           curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,15 +199,15 @@ jobs:
           apt-get install -y nodejs libfontconfig-dev:${{matrix.arch}} libsecret-1-dev:${{matrix.arch}} libnss3:${{matrix.arch}} libatk1.0-0:${{matrix.arch}} libatk-bridge2.0-0:${{matrix.arch}} libgdk-pixbuf2.0-0:${{matrix.arch}} libgtk-3-0:${{matrix.arch}} libgbm1:${{matrix.arch}}
           export CC=${{matrix.triplet}}gcc CXX=${{matrix.triplet}}g++ ARCH=${{matrix.build-arch}}
           export npm_config_arch=${{matrix.build-arch}} npm_config_target_arch=${{matrix.build-arch}}
-          npm i -g yarn node-pre-gyp
-          yarn --network-timeout 1000000 --arch=${{matrix.arch}}
+          npm i -g yarn
+          yarn --network-timeout 1000000 --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           cd ./app/node_modules/node-pty 
           npx node-gyp configure build
           cd ../../
           echo Rebuilding node-pty
-          yarn rebuild node-pty
+          npm rebuild node-pty --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}
           cd ..
-          yarn run build"
+          yarn run build --arch=${{matrix.build-arch}} --target_arch=${{matrix.build-arch}}"
       if: matrix.build-arch != 'x64'
 
     - name: Prepackage plugins (${{matrix.build-arch}})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,9 +136,9 @@ jobs:
           - build-arch: arm64
             arch: arm64
             triplet: aarch64-linux-gnu-
-#           - build-arch: armv7l
-#             arch: armhf
-#             triplet: arm-linux-gnueabihf-
+          - build-arch: armv7l
+            arch: armhf
+            triplet: arm-linux-gnueabihf-
     env:
       CC: ${{matrix.triplet}}-gcc
       CXX: ${{matrix.triplet}}-g++
@@ -155,7 +155,7 @@ jobs:
     - name: Install Node
       uses: actions/setup-node@v3.6.0
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Install deps (x64)
       run: |
@@ -178,8 +178,9 @@ jobs:
           sudo debootstrap --include=git,curl,gnupg,ca-certificates,crossbuild-essential-${{matrix.arch}},libarchive-tools,cmake --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --cache-dir=/tmp/debootstrap-cache/ bionic /build-chroot/
           echo 'deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse' | sudo tee /build-chroot/etc/apt/sources.list >/dev/null
           echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse' | sudo tee -a /build-chroot/etc/apt/sources.list >/dev/null
-          curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee /build-chroot/etc/apt/trusted.gpg.d/nodesource.gpg >/dev/null
-          echo 'deb http://deb.nodesource.com/node_16.x bionic main' | sudo tee /build-chroot/etc/apt/sources.list.d/nodesource.list >/dev/null
+          curl https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz -o node.tar.xz
+          tar -xJf node-v18.16.0-linux-x64.tar.xz
+          sudo cp node-v18.16.0-linux-x64/* /build-chroot/usr/local/ -R
           echo "[build-chroot]
           description=Ubuntu 18.04 Build chroot
           type=directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,6 +290,12 @@ jobs:
         dir: 'dist'
 
     - uses: actions/upload-artifact@master
+      name: Upload AppImage (${{matrix.arch}})
+      with:
+        name: Linux AppImage (${{matrix.arch}})
+        path: dist/*.AppImage
+    
+    - uses: actions/upload-artifact@master
       name: Upload DEB (${{matrix.arch}})
       with:
         name: Linux DEB (${{matrix.arch}})

--- a/HACKING.md
+++ b/HACKING.md
@@ -17,8 +17,6 @@ First, from within the `tabby` directory install the dependencies via yarn:
 yarn
 ```
 
-**Note: For compiling for Linux armv7l, you need to downgrade electron to 17.0.0 in package.json present in root directory of tabby source**
-
 ```
 # Linux (Debian/Ubuntu here as an example)
 sudo apt install libfontconfig-dev libsecret-1-dev libarchive-tools libnss3 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 cmake

--- a/app/lib/pty.ts
+++ b/app/lib/pty.ts
@@ -1,4 +1,4 @@
-import * as nodePTY from '@tabby-gang/node-pty'
+import * as nodePTY from 'node-pty'
 import { v4 as uuidv4 } from 'uuid'
 import { ipcMain } from 'electron'
 import { Application } from './app'

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@electron/remote": "2.0.10",
-    "@tabby-gang/node-pty": "^0.11.0-beta.203",
+    "node-pty": "^0.11.0-beta32",
     "any-promise": "^1.3.0",
     "electron-config": "2.0.0",
     "electron-debug": "^3.2.0",

--- a/app/webpack.config.main.mjs
+++ b/app/webpack.config.main.mjs
@@ -47,7 +47,7 @@ const config = {
         mz: 'commonjs mz',
         npm: 'commonjs npm',
         'node:os': 'commonjs os',
-        '@tabby-gang/node-pty': 'commonjs @tabby-gang/node-pty',
+        'node-pty': 'commonjs node-pty',
         path: 'commonjs path',
         util: 'commonjs util',
         'source-map-support': 'commonjs source-map-support',

--- a/scripts/build-linux.mjs
+++ b/scripts/build-linux.mjs
@@ -9,7 +9,7 @@ process.env.ARCH = (process.env.ARCH || process.arch) === 'arm' ? 'armv7l' : pro
 
 builder({
     dir: true,
-    linux: ['deb', 'tar.gz', 'rpm', 'pacman'],
+    linux: ['deb', 'tar.gz', 'rpm', 'pacman', 'appimage'],
     armv7l: process.env.ARCH === 'armv7l',
     arm64: process.env.ARCH === 'arm64',
     config: {

--- a/scripts/sentry-upload.mjs
+++ b/scripts/sentry-upload.mjs
@@ -9,7 +9,7 @@ sh.exec(`${sentryCli} releases new ${vars.version}`)
 if (process.platform === 'darwin') {
     for (const path of [
         'app/node_modules/@serialport/bindings/build/Release/bindings.node',
-        'app/node_modules/@tabby-gang/node-pty/build/Release/pty.node',
+        'app/node_modules/node-pty/build/Release/pty.node',
         'app/node_modules/fontmanager-redux/build/Release/fontmanager.node',
         'app/node_modules/macos-native-processlist/build/Release/native.node',
     ]) {

--- a/scripts/vars.mjs
+++ b/scripts/vars.mjs
@@ -3,6 +3,8 @@ import * as fs from 'fs'
 import * as semver from 'semver'
 import * as childProcess from 'child_process'
 
+process.env.ARCH = ((process.env.ARCH || process.arch) === 'arm') ? 'armv7l' : process.env.ARCH || process.arch
+
 import * as url from 'url'
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
@@ -58,21 +60,21 @@ export const keygenConfig = {
         win32: {
             x64: 'f481b9d6-d5da-4970-b926-f515373e986f',
             arm64: '950999b9-371c-419b-b291-938c5e4d364c',
-        }[process.env.ARCH ?? process.arch],
+        }[process.env.ARCH],
         darwin: {
             arm64: '98fbadee-c707-4cd6-9d99-56683595a846',
             x86_64: 'f5a48841-d5b8-4b7b-aaa7-cf5bffd36461',
             x64: 'f5a48841-d5b8-4b7b-aaa7-cf5bffd36461',
-        }[process.env.ARCH ?? process.arch],
+        }[process.env.ARCH],
         linux: {
             x64: '7bf45071-3031-4a26-9f2e-72604308313e',
             arm64: '39e3c736-d4d4-4fbf-a201-324b7bab0d17',
             armv7l: '50ae0a82-7f47-4fa4-b0a8-b0d575ce9409',
             armhf: '7df5aa12-04ab-4075-a0fe-93b0bbea9643',
-        }[process.env.ARCH ?? process.arch],
+        }[process.env.ARCH],
     }[process.platform],
 }
 
 if (!keygenConfig.product) {
-    throw new Error(`Unrecognized platform ${process.platform}/${process.env.ARCH ?? process.arch}`)
+    throw new Error(`Unrecognized platform ${process.platform}/${process.env.ARCH}`)
 }


### PR DESCRIPTION
@Eugeny
This (finally!!) implements a better way to compile tabby for arm linux platforms than docker, quite complex than before but faster. 
Completes in ~25-35 mins as compared to ~2 hours with docker based compilation method used previously.

EDIT: Also added AppImage target for linux

Previous approach is still left **_commented_** in place. 
***TESTED working on both arm64 and armhf***

Also updated dependency from `@tabby-gang/node-pty` to `note-pty` as it has a new beta release in March. (Feel free to discard this.)

Add better cross-compilation support to `scripts/vars.mjs`

Prefer squash merge on this PR due to its dirty commit history.
