### PR TITLE
Feat#5688: Save As Profile option available for all tabs

### DIFF
--- a/tabby-core/src/services/config.service.ts
+++ b/tabby-core/src/services/config.service.ts
@@ -205,7 +205,7 @@ export class ConfigService {
         // Scrub undefined values
         let cleanStore = JSON.parse(JSON.stringify(this._store))
         cleanStore = await this.maybeEncryptConfig(cleanStore)
-        await this.platform.saveConfig(yaml.dump(cleanStore))
+        await this.platform.saveConfig(yaml.dump(cleanStore, {skipInvalid: true}))
         this.emitChange()
     }
 
@@ -213,7 +213,7 @@ export class ConfigService {
      * Reads config YAML as string
      */
     readRaw (): string {
-        return yaml.dump(this._store)
+        return yaml.dump(this._store, {skipInvalid: true})
     }
 
     /**

--- a/tabby-core/src/services/config.service.ts
+++ b/tabby-core/src/services/config.service.ts
@@ -205,7 +205,7 @@ export class ConfigService {
         // Scrub undefined values
         let cleanStore = JSON.parse(JSON.stringify(this._store))
         cleanStore = await this.maybeEncryptConfig(cleanStore)
-        await this.platform.saveConfig(yaml.dump(cleanStore, {skipInvalid: true}))
+        await this.platform.saveConfig(yaml.dump(cleanStore, { skipInvalid: true }))
         this.emitChange()
     }
 
@@ -213,7 +213,7 @@ export class ConfigService {
      * Reads config YAML as string
      */
     readRaw (): string {
-        return yaml.dump(this._store, {skipInvalid: true})
+        return yaml.dump(this._store, { skipInvalid: true })
     }
 
     /**

--- a/tabby-local/src/index.ts
+++ b/tabby-local/src/index.ts
@@ -21,7 +21,7 @@ import { RecoveryProvider } from './recoveryProvider'
 import { ShellSettingsTabProvider } from './settings'
 import { TerminalConfigProvider } from './config'
 import { LocalTerminalHotkeyProvider } from './hotkeys'
-import { NewTabContextMenu, SaveAsProfileContextMenu } from './tabContextMenu'
+import { NewTabContextMenu } from './tabContextMenu'
 
 import { AutoOpenTabCLIHandler, OpenPathCLIHandler, TerminalCLIHandler } from './cli'
 import { LocalProfilesService } from './profiles'
@@ -47,7 +47,6 @@ import { LocalProfilesService } from './profiles'
         { provide: ProfileProvider, useClass: LocalProfilesService, multi: true },
 
         { provide: TabContextMenuItemProvider, useClass: NewTabContextMenu, multi: true },
-        { provide: TabContextMenuItemProvider, useClass: SaveAsProfileContextMenu, multi: true },
 
         { provide: CLIHandler, useClass: TerminalCLIHandler, multi: true },
         { provide: CLIHandler, useClass: OpenPathCLIHandler, multi: true },

--- a/tabby-local/src/tabContextMenu.ts
+++ b/tabby-local/src/tabContextMenu.ts
@@ -1,58 +1,8 @@
 import { Inject, Injectable, Optional } from '@angular/core'
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigService, BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, ProfilesService, PromptModalComponent, TranslateService } from 'tabby-core'
+import { ConfigService, BaseTabComponent, TabContextMenuItemProvider, MenuItemOptions, ProfilesService, TranslateService } from 'tabby-core'
 import { TerminalTabComponent } from './components/terminalTab.component'
 import { TerminalService } from './services/terminal.service'
 import { LocalProfile, UACService } from './api'
-
-/** @hidden */
-@Injectable()
-export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
-    constructor (
-        private config: ConfigService,
-        private ngbModal: NgbModal,
-        private notifications: NotificationsService,
-        private translate: TranslateService,
-    ) {
-        super()
-    }
-
-    async getItems (tab: BaseTabComponent): Promise<MenuItemOptions[]> {
-        if (!(tab instanceof TerminalTabComponent)) {
-            return []
-        }
-        const terminalTab = tab
-        const items: MenuItemOptions[] = [
-            {
-                label: this.translate.instant('Save as profile'),
-                click: async () => {
-                    const modal = this.ngbModal.open(PromptModalComponent)
-                    modal.componentInstance.prompt = this.translate.instant('New profile name')
-                    const name = (await modal.result)?.value
-                    if (!name) {
-                        return
-                    }
-                    const profile = {
-                        options: {
-                            ...terminalTab.profile.options,
-                            cwd: await terminalTab.session?.getWorkingDirectory() ?? terminalTab.profile.options.cwd,
-                        },
-                        name,
-                        type: 'local',
-                    }
-                    this.config.store.profiles = [
-                        ...this.config.store.profiles,
-                        profile,
-                    ]
-                    this.config.save()
-                    this.notifications.info(this.translate.instant('Saved'))
-                },
-            },
-        ]
-
-        return items
-    }
-}
 
 /** @hidden */
 @Injectable()

--- a/tabby-settings/src/services/configSync.service.ts
+++ b/tabby-settings/src/services/configSync.service.ts
@@ -97,7 +97,7 @@ export class ConfigSyncService {
                     data[part] = remoteData[part]
                 }
             }
-            const content = yaml.dump(data, {skipInvalid: true})
+            const content = yaml.dump(data, { skipInvalid: true })
             const result = await this.updateConfig(this.config.store.configSync.configID, {
                 content,
                 last_used_with_version: this.platform.getAppVersion(),
@@ -154,7 +154,7 @@ export class ConfigSyncService {
     }
 
     private async writeConfigDataFromSync (data: any) {
-        await this.platform.saveConfig(yaml.dump(data, {skipInvalid: true}))
+        await this.platform.saveConfig(yaml.dump(data, { skipInvalid: true }))
         await this.config.load()
         await this.config.save()
     }

--- a/tabby-settings/src/services/configSync.service.ts
+++ b/tabby-settings/src/services/configSync.service.ts
@@ -97,7 +97,7 @@ export class ConfigSyncService {
                     data[part] = remoteData[part]
                 }
             }
-            const content = yaml.dump(data)
+            const content = yaml.dump(data, {skipInvalid: true})
             const result = await this.updateConfig(this.config.store.configSync.configID, {
                 content,
                 last_used_with_version: this.platform.getAppVersion(),
@@ -154,7 +154,7 @@ export class ConfigSyncService {
     }
 
     private async writeConfigDataFromSync (data: any) {
-        await this.platform.saveConfig(yaml.dump(data))
+        await this.platform.saveConfig(yaml.dump(data, {skipInvalid: true}))
         await this.config.load()
         await this.config.save()
     }

--- a/tabby-terminal/src/index.ts
+++ b/tabby-terminal/src/index.ts
@@ -28,7 +28,7 @@ import { PathDropDecorator } from './features/pathDrop'
 import { ZModemDecorator } from './features/zmodem'
 import { TerminalConfigProvider } from './config'
 import { TerminalHotkeyProvider } from './hotkeys'
-import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu } from './tabContextMenu'
+import { CopyPasteContextMenu, MiscContextMenu, LegacyContextMenu, ReconnectContextMenu, SaveAsProfileContextMenu } from './tabContextMenu'
 
 import { Frontend } from './frontends/frontend'
 import { XTermFrontend, XTermWebGLFrontend } from './frontends/xtermFrontend'
@@ -60,6 +60,7 @@ import { DefaultColorSchemes } from './colorSchemes'
         { provide: TabContextMenuItemProvider, useClass: MiscContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: LegacyContextMenu, multi: true },
         { provide: TabContextMenuItemProvider, useClass: ReconnectContextMenu, multi: true },
+        { provide: TabContextMenuItemProvider, useClass: SaveAsProfileContextMenu, multi: true },
 
         { provide: CLIHandler, useClass: TerminalCLIHandler, multi: true },
         { provide: TerminalColorSchemeProvider, useClass: DefaultColorSchemes, multi: true },

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile} from 'tabby-core'
+import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
@@ -180,8 +180,8 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
                             return
                         }
 
-                        let options = {
-                            ...tab.profile.options
+                        const options = {
+                            ...tab.profile.options,
                         }
 
                         const cwd = await tab.session?.getWorkingDirectory() ?? tab.profile.options.cwd
@@ -192,7 +192,7 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
                         const profile: PartialProfile<Profile> = {
                             type: tab.profile.type,
                             name,
-                            options
+                            options,
                         }
 
                         profile.id = `${profile.type}:custom:${slugify(name)}:${uuidv4()}`

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,10 +1,12 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService } from 'tabby-core'
+import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile } from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
 import { ConnectableTerminalTabComponent } from './api/connectableTerminalTab.component'
+import { v4 as uuidv4 } from 'uuid'
+import slugify from 'slugify'
 
 /** @hidden */
 @Injectable()
@@ -186,13 +188,13 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
                             }
                         }
 
-                        const profile = {
+                        const profile: PartialProfile<Profile> = {
                             options,
                             name,
                             type: tab.profile.type,
                         }
 
-                        console.log(profile)
+                        profile.id = `${profile.type}:custom:${slugify(profile.name)}:${uuidv4()}`
 
                         this.config.store.profiles = [
                             ...this.config.store.profiles,

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile } from 'tabby-core'
+import { BaseTabComponent, TabContextMenuItemProvider, NotificationsService, MenuItemOptions, TranslateService, SplitTabComponent, PromptModalComponent, ConfigService, PartialProfile, Profile} from 'tabby-core'
 import { BaseTerminalTabComponent } from './api/baseTerminalTab.component'
 import { TerminalContextMenuItemProvider } from './api/contextMenuProvider'
 import { MultifocusService } from './services/multifocus.service'
@@ -174,27 +174,33 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
                     click: async () => {
                         const modal = this.ngbModal.open(PromptModalComponent)
                         modal.componentInstance.prompt = this.translate.instant('New profile name')
+                        modal.componentInstance.value = tab.profile.name
                         const name = (await modal.result)?.value
                         if (!name) {
                             return
                         }
 
-                        let options = {...tab.profile.options}
+                        let options = {
+                            ...tab.profile.options
+                        }
+
                         const cwd = await tab.session?.getWorkingDirectory() ?? tab.profile.options.cwd
                         if (cwd) {
-                            options = { 
-                                ...options,
-                                cwd
-                            }
+                            options.cwd = cwd
                         }
 
                         const profile: PartialProfile<Profile> = {
-                            options,
-                            name,
                             type: tab.profile.type,
+                            name,
+                            options
                         }
 
-                        profile.id = `${profile.type}:custom:${slugify(profile.name)}:${uuidv4()}`
+                        profile.id = `${profile.type}:custom:${slugify(name)}:${uuidv4()}`
+                        profile.group = tab.profile.group
+                        profile.icon = tab.profile.icon
+                        profile.color = tab.profile.color
+                        profile.disableDynamicTitle = tab.profile.disableDynamicTitle
+                        profile.behaviorOnSessionEnd = tab.profile.behaviorOnSessionEnd
 
                         this.config.store.profiles = [
                             ...this.config.store.profiles,


### PR DESCRIPTION
Hi @Eugeny, I hope you are doing well !

I took a look on the feature request #5688 . This PR aims to make the 'Save As Profile' context menu item available for all tabs.

1. I saw that they were no ID setted with the new saved profile before. It causes the profile to not be shown in the `Profiles & Connections` selector since the commit c983743 : 
https://github.com/Eugeny/tabby/blob/c983743b57d90246d997b1ebf328a5c6696ac315/tabby-core/src/services/profiles.service.ts#L156
Should we create a recovery mechanism? Like creating an ID for profile those does not have one when the config is saved. What would be your approach on this?

2. During my test, I encountered the same issue as the one describe in #8534. https://github.com/Eugeny/tabby/blob/c983743b57d90246d997b1ebf328a5c6696ac315/tabby-core/src/services/config.service.ts#L200-L210 Even with `JSON.parse(JSON.stringify(this._store))` and in rare case, some invalid yaml type seems to be present in the config object on yaml dump. Sadly I wasn't able to identify which part precisely... Anyway, adding `skipInvalid: true` in yaml dump option prevent the method to rise `{name: 'YAMLException', reason: 'unacceptable kind of an object to dump [object Function]'}` by skipping invalid type.

3. Also, It could be great to do a bit of refactoring in the future and create methods in the ProfileService for profile creation, edition and deletion to have only one entrypoint for profile operation. It would be simpler to maintain. What do you think ?

As always, feel free to ask me if changes needed :)

Resolve #5688 