### PR TITLE
Feat#8680: add "connect to" option in profile selector for each provider supporting quick connect

### DIFF
--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -76,10 +76,11 @@ export class SelectorModalComponent<T> {
                 { sort: true },
             ).search(f)
 
-            const freeOption = this.options.find(x => x.freeInputPattern)
-            if (freeOption && !this.filteredOptions.includes(freeOption)) {
-                this.filteredOptions.push(freeOption)
-            }
+            this.options.filter(x => x.freeInputPattern).forEach(freeOption => {
+                if (freeOption && !this.filteredOptions.includes(freeOption)) {
+                    this.filteredOptions.push(freeOption)
+                }
+            })
         }
         this.selectedIndex = Math.max(0, this.selectedIndex)
         this.selectedIndex = Math.min(this.filteredOptions.length - 1, this.selectedIndex)

--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -77,7 +77,7 @@ export class SelectorModalComponent<T> {
             ).search(f)
 
             this.options.filter(x => x.freeInputPattern).forEach(freeOption => {
-                if (freeOption && !this.filteredOptions.includes(freeOption)) {
+                if (!this.filteredOptions.includes(freeOption)) {
                     this.filteredOptions.push(freeOption)
                 }
             })

--- a/tabby-core/src/configDefaults.yaml
+++ b/tabby-core/src/configDefaults.yaml
@@ -54,3 +54,4 @@ hacks:
   disableVibrancyWhileDragging: false
   enableFluentBackground: false
 language: null
+defaultQuickConnectProvider: "ssh"

--- a/tabby-core/src/index.ts
+++ b/tabby-core/src/index.ts
@@ -219,6 +219,7 @@ export default class AppModule { // eslint-disable-line @typescript-eslint/no-ex
                 name: this.translate.instant('Quick connect'),
                 freeInputPattern: this.translate.instant('Connect to "%s"...'),
                 icon: 'fas fa-arrow-right',
+                description: `(${provider.name.toUpperCase()})`,
                 callback: query => {
                     const p = provider.quickConnect(query)
                     if (p) {

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -183,6 +183,7 @@ export class ProfilesService {
                         freeInputPattern: this.translate.instant('Connect to "%s"...'),
                         description: `(${provider.name.toUpperCase()})`,
                         icon: 'fas fa-arrow-right',
+                        weight: provider.id !== this.config.store.defaultQuickConnectProvider ? 1 : 0,
                         callback: query => {
                             const profile = provider.quickConnect(query)
                             resolve(profile)

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -177,17 +177,19 @@ export class ProfilesService {
                     })
                 } catch { }
 
-                if (this.getProviders().some(x => x.supportsQuickConnect)) {
+                this.getProviders().filter(x => x.supportsQuickConnect).forEach(provider => {
                     options.push({
                         name: this.translate.instant('Quick connect'),
                         freeInputPattern: this.translate.instant('Connect to "%s"...'),
+                        description: `(${provider.name.toUpperCase()})`,
                         icon: 'fas fa-arrow-right',
                         callback: query => {
-                            const profile = this.quickConnect(query)
+                            const profile = provider.quickConnect(query)
                             resolve(profile)
                         },
                     })
-                }
+                })
+
                 await this.selector.show(this.translate.instant('Select profile or enter an address'), options)
             } catch (err) {
                 reject(err)

--- a/tabby-settings/src/components/profilesSettingsTab.component.pug
+++ b/tabby-settings/src/components/profilesSettingsTab.component.pug
@@ -149,6 +149,20 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                     option(ngValue='wt', translation) Windows Terminal
                     option(ngValue='cygwin', translation) Cygwin
 
+            .form-line
+                .header
+                    .title(translate) Default "Connect to" type
+                    .description(translate) Default connection type used by quick connect feature (ex. SSH, Telnet)
+
+                select.form-control(
+                    [(ngModel)]='config.store.defaultQuickConnectProvider',
+                    (ngModelChange)='config.save()',
+                )
+                    option(
+                        *ngFor='let provider of getQuickConnectProviders()',
+                        [ngValue]='provider.id'
+                    ) {{provider.name}}
+
             .form-line.content-box
                 .header
                     .title(translate) Default profile settings

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -312,4 +312,8 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     isProfileBlacklisted (profile: PartialProfile<Profile>): boolean {
         return profile.id && this.config.store.profileBlacklist.includes(profile.id)
     }
+
+    getQuickConnectProviders (): ProfileProvider<Profile>[] {
+        return this.profileProviders.filter(x => x.supportsQuickConnect)
+    }
 }

--- a/tabby-telnet/src/profiles.ts
+++ b/tabby-telnet/src/profiles.ts
@@ -8,7 +8,7 @@ import { TelnetProfile } from './session'
 export class TelnetProfilesService extends ProfileProvider<TelnetProfile> {
     id = 'telnet'
     name = 'Telnet'
-    supportsQuickConnect = false
+    supportsQuickConnect = true
     settingsComponent = TelnetProfileSettingsComponent
     configDefaults = {
         options: {


### PR DESCRIPTION
Hi @Eugeny :)

As discuss in #8680, this PR aims to add "connect to" option in profile selector for each provider supporting quick connect:
![image](https://github.com/Eugeny/tabby/assets/20025949/dec084eb-27fd-45b5-a836-81c5b43d4a16)

Should we create a configuration to put weight on "connect to" option? It would allow users to choose which "Connect to" option have to be on top of the list according to their habit.

Feel free to ask me if changes needed!


Resolve #8680 