### PR TITLE
add tabby-sftp-tab plugin implement open sftp tab for ssh connection

### DIFF
--- a/README.de-DE.md
+++ b/README.de-DE.md
@@ -43,14 +43,14 @@ Diese README ist auch verfügbar in: <a  href="./README.md">:gb: English</a> · 
 
 # Inhaltsverzeichnis <!-- omit in toc -->
 
-- [Was Tabby ist und was nicht](#what-tabby-is-and-isnt)
-- [Terminal-Funktionen](#terminal-features)
+- [Was Tabby ist und was nicht](#was-tabby-ist-und-was-nicht)
+- [Terminal-Funktionen](#terminal-funktionen)
 - [SSH Client](#ssh-client)
-- [Serielles Terminal](#serial-terminal)
-- [Portabel](#portable)
+- [Serielles Terminal](#serielles-terminal)
+- [Portabel](#portabel)
 - [Plugins](#plugins)
-- [Themen](#themes)
-- [Beitragen](#contributing)
+- [Themen](#themen)
+- [Beitragen](#beitragen)
 
 <a  name="about"></a>
 
@@ -119,6 +119,7 @@ Plugins und Themen können direkt aus der Ansicht "Einstellungen" in Tabby insta
 * [clippy](https://github.com/Eugeny/tabby-clippy) - ein Beispiel-Plugin, das einen die ganze Zeit nervt
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - ermöglicht das Erstellen eigener Workspace-Profile auf Basis der angegebenen Konfiguration
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - öffnet den Standard-Systembrowser mit einem Text, der aus dem Tabby Tab ausgewählt wurde
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a  name="themes"></a>
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -44,14 +44,14 @@ Este fichero README está disponible en: <a  href="./README.md">:gb: English</a>
 
 # Contenidos <!-- omit in toc -->
 
-- [¿Qué es Tabby y que no es?](#what-tabby-is-and-isnt)
-- [Características de Terminal](#terminal-features)
-- [Cliente SSH](#ssh-client)
-- [Terminal Serie](#serial-terminal)
+- [¿Qué es Tabby y que no es?](#qué-es-tabby-y-que-no-es)
+- [Características de Terminal](#características-de-terminal)
+- [Cliente SSH](#cliente-ssh)
+- [Terminal Serie](#terminal-serie)
 - [Portable](#portable)
 - [Plugins](#plugins)
-- [Temas](#themes)
-- [Contribuciones](#contributing)
+- [Temas](#temas)
+- [Contribuciones](#contribuciones)
 
 <a name="about"></a>
 
@@ -120,6 +120,7 @@ Los plugins y los temas se pueden instalar directamente desde la vista de Config
 * [clippy](https://github.com/Eugeny/tabby-clippy) - un ejemplo de plugin que te molesta todo el tiempo
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - permite crear perfiles de espacio de trabajo personalizados basados en la configuración dada
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - abre el navegador del sistema por defecto con un texto seleccionado en la pestaña de Tabby's
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 <a name="themes"></a>
 
 # Temas

--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -44,14 +44,14 @@ This README is also available in: <a  href="./README.md">:gb: English</a> · <a 
 
 # Contents <!-- omit in toc -->
 
-- [Apa itu Tabby dan bukan Tabby](#what-tabby-is-and-isnt)
-- [Fitur Terminal](#terminal-features)
-- [SSH Client](#ssh-client)
+- [Apa itu Tabby dan bukan Tabby](#apa-itu-tabby-dan-bukan-tabby)
+- [Fitur terminal](#fitur-terminal)
+- [Klien SSH](#klien-ssh)
 - [Serial Terminal](#serial-terminal)
-- [Portabel](#portable)
+- [Portabel](#portabel)
 - [Plugins](#plugins)
-- [Tema](#themes)
-- [Kontribusi](#contributing)
+- [Tema](#tema)
+- [Kontribusi](#kontribusi)
 
 <a name="about"></a>
 
@@ -120,6 +120,7 @@ Tema dan Plugin bisa langsung di install dari Pengaturan di dalam Tabby.
 * [clippy](https://github.com/Eugeny/tabby-clippy) - suatu contoh plugin yang akan mengganggu anda setiap saat
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - memperbolehkan membuat kustom profil workspace dari konfigurasi yang diberikan
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - membuka browser default dengan text yang dipilih dari Tab Tabby
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 

--- a/README.it-IT.md
+++ b/README.it-IT.md
@@ -117,6 +117,7 @@ Plugins and themes can be installed directly from the Settings view inside Tabby
 * [clippy](https://github.com/Eugeny/tabby-clippy) - an example plugin which annoys you all the time
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - allows creating custom workspace profiles based on the given config
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - opens default system browser with a text selected from the Tabby's tab
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 # Temi

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -127,6 +127,7 @@ Windows上では、`Tabby.exe`がある場所と同じ場所に`data`フォル�
 * [clippy](https://github.com/Eugeny/tabby-clippy) - プラグインの作例として、いつも厄介なあいつが出てくるプラグイン
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - 指定された設定からカスタマイズされたワークスペースを作成することができます
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - Tabby内の端末で選択したテキストを既定ブラウザで開くことができます。
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -111,6 +111,7 @@
 * [clippy](https://github.com/Eugeny/tabby-clippy) - 항상 당신을 귀찮게 하는 예제 플러그인
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - 주어진 구성을 기반으로 사용자 정의 작업 공간 프로필을 생성할 수 있습니다
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - Tabby의 탭에서 선택한 텍스트로 기본 시스템 브라우저를 엽니다
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 # 테마

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Plugins and themes can be installed directly from the Settings view inside Tabby
 * [clippy](https://github.com/Eugeny/tabby-clippy) - an example plugin which annoys you all the time
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - allows creating custom workspace profiles based on the given config
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - opens default system browser with a text selected from the Tabby's tab
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -44,14 +44,14 @@ Esse README também está disponível em: <a  href="./README.md">:gb: English</a
 
 # Conteúdo <!-- omit in toc -->
 
-- [O que é Tabby e o que não é](#what-tabby-is-and-isnt)
-- [Recursos do Terminal](#terminal-features)
-- [Cliente SSH](#ssh-client)
-- [Terminal Serial](#serial-terminal)
-- [Portátil](#portable)
+- [O que é Tabby e o que não é](#o-que-é-tabby-e-o-que-não-é)
+- [Recursos do Terminal](#recursos-do-terminal)
+- [Cliente SSH](#cliente-ssh)
+- [Terminal Serial](#terminal-serial)
+- [Portátil](#portátil)
 - [Plugins](#plugins)
-- [Temas](#themes)
-- [Contribuições](#contributing)
+- [Temas](#temas)
+- [Contribuições](#contribuições)
 
 <a name="about"></a>
 
@@ -120,6 +120,7 @@ Plugins e temas podem ser instalados durante a execução na pagina de configura
 * [clippy](https://github.com/Eugeny/tabby-clippy) - um plugin de exemplo que te incomoda o tempo todo
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - permite criar perfis de espaço de trabalho personalizados com base na configuração fornecida
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - abre o navegador padrão do sistema com um texto selecionado na guia do Tabby
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -117,6 +117,7 @@
 * [clippy](https://github.com/Eugeny/tabby-clippy) — плагин-пример, который постоянно будет вас бесить;
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) — позволяет создавать пользовательские провили рабочего окружеиня на основе конфига;
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) — открывает браузер по умолчанию с текстом, выделенном во вкладке Tabby.
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection
 
 <a name="themes"></a>
 # Темы

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,6 +116,7 @@
 * [clippy](https://github.com/Eugeny/tabby-clippy) - 一个可以一直烦你的示例插件
 * [workspace-manager](https://github.com/composer404/tabby-workspace-manager) - 允许根据给定的配置创建自定义工作区配置文件
 * [search-in-browser](https://github.com/composer404/tabby-search-in-browser) - 从 Tabby 标签页带有选中的文本来打开系统默认浏览器
+* [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - 为ssh连接打开sftp标签页
 
 <a name="themes"></a>
 # 主题


### PR DESCRIPTION
Adding an introduction to sftp tab, people who switch from SecureCRT to Tabby may want to use similar features of sftp tab.