### PR TITLE
Fix#8839: Cannot select item from command selector

### DIFF
--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -33,10 +33,11 @@ export class SelectorModalComponent<T> {
             this.close()
         } else if (this.filteredOptions.length > 0) {
             if (event.key === 'PageUp' || event.key === 'ArrowUp' && event.metaKey) {
-                this.selectedIndex -= 10
+                this.selectedIndex -= Math.min(10, this.selectedIndex === 0 ? 1 : this.selectedIndex)
                 event.preventDefault()
             } else if (event.key === 'PageDown' || event.key === 'ArrowDown' && event.metaKey) {
-                this.selectedIndex += 10
+                const newI = this.filteredOptions.length - this.selectedIndex - 1
+                this.selectedIndex += Math.min(10, newI === 0 ? 1 : newI)
                 event.preventDefault()
             } else if (event.key === 'ArrowUp') {
                 this.selectedIndex--

--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -29,34 +29,36 @@ export class SelectorModalComponent<T> {
     }
 
     @HostListener('keydown', ['$event']) onKeyUp (event: KeyboardEvent): void {
-        if (event.key === 'PageUp' || event.key === 'ArrowUp' && event.metaKey) {
-            this.selectedIndex -= 10
-            event.preventDefault()
-        } else if (event.key === 'PageDown' || event.key === 'ArrowDown' && event.metaKey) {
-            this.selectedIndex += 10
-            event.preventDefault()
-        } else if (event.key === 'ArrowUp') {
-            this.selectedIndex--
-            event.preventDefault()
-        } else if (event.key === 'ArrowDown') {
-            this.selectedIndex++
-            event.preventDefault()
-        } else if (event.key === 'Enter') {
-            this.selectOption(this.filteredOptions[this.selectedIndex])
-        } else if (event.key === 'Escape') {
+        if (event.key === 'Escape') {
             this.close()
-        }
-        if (event.key === 'Backspace' && this.canEditSelected()) {
-            event.preventDefault()
-            this.filter = this.filteredOptions[this.selectedIndex].freeInputEquivalent!
-            this.onFilterChange()
-        }
+        } else if (this.filteredOptions.length > 0) {
+            if (event.key === 'PageUp' || event.key === 'ArrowUp' && event.metaKey) {
+                this.selectedIndex -= 10
+                event.preventDefault()
+            } else if (event.key === 'PageDown' || event.key === 'ArrowDown' && event.metaKey) {
+                this.selectedIndex += 10
+                event.preventDefault()
+            } else if (event.key === 'ArrowUp') {
+                this.selectedIndex--
+                event.preventDefault()
+            } else if (event.key === 'ArrowDown') {
+                this.selectedIndex++
+                event.preventDefault()
+            } else if (event.key === 'Enter') {
+                this.selectOption(this.filteredOptions[this.selectedIndex])
+            } else if (event.key === 'Backspace' && this.canEditSelected()) {
+                event.preventDefault()
+                this.filter = this.filteredOptions[this.selectedIndex].freeInputEquivalent!
+                this.onFilterChange()
+            }
 
-        this.selectedIndex = (this.selectedIndex + this.filteredOptions.length) % this.filteredOptions.length
-        Array.from(this.itemChildren)[this.selectedIndex]?.nativeElement.scrollIntoView({
-            behavior: 'smooth',
-            block: 'nearest',
-        })
+            this.selectedIndex = (this.selectedIndex + this.filteredOptions.length) % this.filteredOptions.length
+
+            Array.from(this.itemChildren)[this.selectedIndex]?.nativeElement.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+            })
+        }
     }
 
     onFilterChange (): void {

--- a/tabby-core/src/components/selectorModal.component.ts
+++ b/tabby-core/src/components/selectorModal.component.ts
@@ -33,11 +33,10 @@ export class SelectorModalComponent<T> {
             this.close()
         } else if (this.filteredOptions.length > 0) {
             if (event.key === 'PageUp' || event.key === 'ArrowUp' && event.metaKey) {
-                this.selectedIndex -= Math.min(10, this.selectedIndex === 0 ? 1 : this.selectedIndex)
+                this.selectedIndex -= Math.min(10, Math.max(1, this.selectedIndex))
                 event.preventDefault()
             } else if (event.key === 'PageDown' || event.key === 'ArrowDown' && event.metaKey) {
-                const newI = this.filteredOptions.length - this.selectedIndex - 1
-                this.selectedIndex += Math.min(10, newI === 0 ? 1 : newI)
+                this.selectedIndex += Math.min(10, Math.max(1, this.filteredOptions.length - this.selectedIndex - 1))
                 event.preventDefault()
             } else if (event.key === 'ArrowUp') {
                 this.selectedIndex--


### PR DESCRIPTION
Hi @Eugeny, I hope all is well with you.

**Fix #8839 :** This PR aims to fix the issue #8839. Commit d35452091048fcb23d49fda35f582988a26e0f67 avoid the `selectedIndex` value to be NaN cause of modulo [`(this.selectedIndex + this.filteredOptions.length) % this.filteredOptions.length`](https://github.com/Eugeny/tabby/blob/2262d5986629a6226a62c43a92f8b76c67fd6bc6/tabby-core/src/components/selectorModal.component.ts#L51) when `filteredOptions` is empty. Once `selectedIndex` in NaN, the `OnFilterChange` method is no longer able to do operation with `selectedIndex` which cause the selector to do not have any element selected any more even if the filter is empty or matches elements.

ad3b03cb839717d98af3eb871ab7c35bf59f954c: I also added a small feature on PageUp & PageDown event to limit the number of elements being skipped when the key is press.

https://github.com/Eugeny/tabby/blob/634d88d220a3471610cbb0df2e784c7c9257d73b/tabby-core/src/components/selectorModal.component.ts#L35-L40

**On 1.0.197:**
Open selector. Select the second element before the end and press PageDown. 
The eighth from the start will be the one selected now.

**With this PR:**
Open selector. Select the second element before the end and press PageDown. 
The last element of the list will be the one selected now.
Press PageDown again.
It will select the first element from the top of the list.
Same inverse behavior on PageUp.

As always, feel free to ask me if any change are needed !