### PR TITLE
Add show secret functionality to vault

### DIFF
--- a/tabby-settings/src/components/showSecretModal.component.pug
+++ b/tabby-settings/src/components/showSecretModal.component.pug
@@ -1,0 +1,15 @@
+h4.modal-header.m-0.pb-0 {{title}}
+.modal-body
+    .input-group.w-100
+        input.form-control(
+            type='text',
+            [(ngModel)]='secret.value',
+            disabled
+        )
+        button.btn.btn-secondary(
+            (click)='copySecret()'
+        )
+            i.fas.fa-copy
+
+.modal-footer
+    button.btn.btn-primary((click)='close()', translate) Close

--- a/tabby-settings/src/components/showSecretModal.component.ts
+++ b/tabby-settings/src/components/showSecretModal.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input } from '@angular/core'
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import {NotificationsService, VaultFileSecret} from "tabby-core";
+
+/** @hidden */
+@Component({
+    templateUrl: './showSecretModal.component.pug',
+})
+export class ShowSecretModalComponent {
+    @Input() title: String
+    @Input() secret: VaultFileSecret
+
+    constructor (
+        public modalInstance: NgbActiveModal,
+        private notifications: NotificationsService
+    ) { }
+
+    close (): void {
+        this.modalInstance.dismiss()
+    }
+
+    copySecret (): void {
+        navigator.clipboard.writeText(this.secret.value)
+        // Show a notification
+        this.notifications.info('Copied to clipboard')
+    }
+}

--- a/tabby-settings/src/components/showSecretModal.component.ts
+++ b/tabby-settings/src/components/showSecretModal.component.ts
@@ -1,18 +1,18 @@
 import { Component, Input } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import {NotificationsService, VaultFileSecret} from "tabby-core";
+import { NotificationsService, VaultFileSecret } from 'tabby-core'
 
 /** @hidden */
 @Component({
     templateUrl: './showSecretModal.component.pug',
 })
 export class ShowSecretModalComponent {
-    @Input() title: String
+    @Input() title: string
     @Input() secret: VaultFileSecret
 
     constructor (
         public modalInstance: NgbActiveModal,
-        private notifications: NotificationsService
+        private notifications: NotificationsService,
     ) { }
 
     close (): void {

--- a/tabby-settings/src/components/vaultSettingsTab.component.pug
+++ b/tabby-settings/src/components/vaultSettingsTab.component.pug
@@ -32,6 +32,9 @@ div(*ngIf='vault.isEnabled()')
                     button.btn.btn-link(ngbDropdownToggle)
                         i.fas.fa-ellipsis-v
                     div(ngbDropdownMenu)
+                        button(ngbDropdownItem, (click)='showSecret(secret)')
+                            i.fas.fa-fw.fa-eye
+                            span(translate) Show
                         button(
                             ngbDropdownItem,
                             *ngIf='secret.type === VAULT_SECRET_TYPE_FILE',

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -3,7 +3,7 @@ import { Component, HostBinding } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { BaseComponent, VaultService, VaultSecret, Vault, PlatformService, ConfigService, VAULT_SECRET_TYPE_FILE, PromptModalComponent, VaultFileSecret, TranslateService } from 'tabby-core'
 import { SetVaultPassphraseModalComponent } from './setVaultPassphraseModal.component'
-import {ShowSecretModalComponent} from "./showSecretModal.component";
+import { ShowSecretModalComponent } from './showSecretModal.component'
 
 
 /** @hidden */

--- a/tabby-settings/src/components/vaultSettingsTab.component.ts
+++ b/tabby-settings/src/components/vaultSettingsTab.component.ts
@@ -3,6 +3,7 @@ import { Component, HostBinding } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { BaseComponent, VaultService, VaultSecret, Vault, PlatformService, ConfigService, VAULT_SECRET_TYPE_FILE, PromptModalComponent, VaultFileSecret, TranslateService } from 'tabby-core'
 import { SetVaultPassphraseModalComponent } from './setVaultPassphraseModal.component'
+import {ShowSecretModalComponent} from "./showSecretModal.component";
 
 
 /** @hidden */
@@ -95,6 +96,16 @@ export class VaultSettingsTabComponent extends BaseComponent {
             return this.translate.instant('File: {description}', (secret as VaultFileSecret).key)
         }
         return this.translate.instant('Unknown secret of type {type} for {key}', { type: secret.type, key: JSON.stringify(secret.key) })
+    }
+
+    showSecret (secret: VaultSecret) {
+        if (!this.vaultContents) {
+            return
+        }
+        const modal = this.ngbModal.open(ShowSecretModalComponent)
+        modal.componentInstance.title = this.getSecretLabel(secret)
+        modal.componentInstance.secret = secret
+
     }
 
     removeSecret (secret: VaultSecret) {

--- a/tabby-settings/src/index.ts
+++ b/tabby-settings/src/index.ts
@@ -19,6 +19,7 @@ import { SetVaultPassphraseModalComponent } from './components/setVaultPassphras
 import { ProfilesSettingsTabComponent } from './components/profilesSettingsTab.component'
 import { ReleaseNotesComponent } from './components/releaseNotesTab.component'
 import { ConfigSyncSettingsTabComponent } from './components/configSyncSettingsTab.component'
+import { ShowSecretModalComponent } from "./components/showSecretModal.component";
 
 import { ConfigSyncService } from './services/configSync.service'
 
@@ -61,6 +62,7 @@ import { HotkeySettingsTabProvider, WindowSettingsTabProvider, VaultSettingsTabP
         WindowSettingsTabComponent,
         ConfigSyncSettingsTabComponent,
         ReleaseNotesComponent,
+        ShowSecretModalComponent,
     ],
 })
 export default class SettingsModule {

--- a/tabby-settings/src/index.ts
+++ b/tabby-settings/src/index.ts
@@ -19,7 +19,7 @@ import { SetVaultPassphraseModalComponent } from './components/setVaultPassphras
 import { ProfilesSettingsTabComponent } from './components/profilesSettingsTab.component'
 import { ReleaseNotesComponent } from './components/releaseNotesTab.component'
 import { ConfigSyncSettingsTabComponent } from './components/configSyncSettingsTab.component'
-import { ShowSecretModalComponent } from "./components/showSecretModal.component";
+import { ShowSecretModalComponent } from './components/showSecretModal.component'
 
 import { ConfigSyncService } from './services/configSync.service'
 


### PR DESCRIPTION
This PR adds a "Show" button to the vault where it is possible to view and copy the passwords of the saved items.

<img width="352" alt="Screenshot" src="https://github.com/Eugeny/tabby/assets/25083973/cccca8b1-0839-4415-b501-d2e58c247a02">

<img width="515" alt="Screenshot" src="https://github.com/Eugeny/tabby/assets/25083973/bd197637-0ac4-4997-9fd3-ee5562138bdc">


This fixes the following issues/feature requests:
https://github.com/Eugeny/tabby/issues/5738
https://github.com/Eugeny/tabby/issues/7194
https://github.com/Eugeny/tabby/issues/4557