### PR TITLE
Fix#8912: clear SSH service messages not working

### DIFF
--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -46,7 +46,9 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     }
 
     protected onFrontendReady (): void {
-        this.initializeSession()
+        this.initializeSession().then(() => {
+            this.clearServiceMessagesOnConnect()
+        })
         super.onFrontendReady()
     }
 
@@ -57,9 +59,6 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     async initializeSession (): Promise<void> {
         this.reconnectOffered = false
         this.isDisconnectedByHand = false
-        if (this.profile.clearServiceMessagesOnConnect) {
-            this.frontend?.clear()
-        }
     }
 
     /**
@@ -119,7 +118,14 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     async reconnect (): Promise<void> {
         this.session?.destroy()
         await this.initializeSession()
+        this.clearServiceMessagesOnConnect()
         this.session?.releaseInitialDataBuffer()
+    }
+
+    private clearServiceMessagesOnConnect (): void {
+        if (this.profile.clearServiceMessagesOnConnect) {
+            this.frontend?.clear()
+        }
     }
 
 }


### PR DESCRIPTION
Hey @Eugeny, I hope you are doing well.

This PR aims to fix the issue #8912. By adding a global connectable tab option for `clearServiceMessagesOnConnect` in #8726 ef6b8a4eaa1ce4cf0311649d009d1a8a3e66a71c, I placed the fronted clear call before session finished to initialize. It results in only cleaning latest terminal session log on reconnection and not service message on connection, which is not intended.

Feel free to ask if any change are needed.