### PR TITLE
Fix#8925: unable to set back a value to the inherited default value on profile

### DIFF
--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -115,10 +115,11 @@ export class ProfilesService {
     async writeProfile (profile: PartialProfile<Profile>): Promise<void> {
         const cProfile = this.config.store.profiles.find(p => p.id === profile.id)
         if (cProfile) {
-            if (!profile.group) {
-                delete cProfile.group
+            // Fully replace the config
+            for (const k in cProfile) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete cProfile[k]
             }
-
             Object.assign(cProfile, profile)
         }
     }

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -70,25 +70,24 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
                 return
             }
         }
-        const profile: PartialProfile<Profile> = deepClone(base)
-        delete profile.id
+        const baseProfile: PartialProfile<Profile> = deepClone(base)
+        delete baseProfile.id
         if (base.isTemplate) {
-            profile.name = ''
+            baseProfile.name = ''
         } else if (!base.isBuiltin) {
-            profile.name = this.translate.instant('{name} copy', base)
+            baseProfile.name = this.translate.instant('{name} copy', base)
         }
-        profile.isBuiltin = false
-        profile.isTemplate = false
-        const result = await this.showProfileEditModal(profile)
+        baseProfile.isBuiltin = false
+        baseProfile.isTemplate = false
+        const result = await this.showProfileEditModal(baseProfile)
         if (!result) {
             return
         }
-        Object.assign(profile, result)
-        if (!profile.name) {
-            const cfgProxy = this.profilesService.getConfigProxyForProfile(profile)
-            profile.name = this.profilesService.providerForProfile(profile)?.getSuggestedName(cfgProxy) ?? this.translate.instant('{name} copy', base)
+        if (!result.name) {
+            const cfgProxy = this.profilesService.getConfigProxyForProfile(result)
+            result.name = this.profilesService.providerForProfile(result)?.getSuggestedName(cfgProxy) ?? this.translate.instant('{name} copy', base)
         }
-        await this.profilesService.newProfile(profile)
+        await this.profilesService.newProfile(result)
         await this.config.save()
     }
 
@@ -97,8 +96,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         if (!result) {
             return
         }
-        Object.assign(profile, result)
-        await this.profilesService.writeProfile(profile)
+        await this.profilesService.writeProfile(result)
         await this.config.save()
     }
 
@@ -117,12 +115,6 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         const result = await modal.result.catch(() => null)
         if (!result) {
             return null
-        }
-
-        // Fully replace the config
-        for (const k in profile) {
-            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-            delete profile[k]
         }
 
         result.type = provider.id
@@ -162,8 +154,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         if (!result) {
             return
         }
-        Object.assign(group, result)
-        await this.profilesService.writeProfileGroup(ProfilesSettingsTabComponent.collapsableIntoPartialProfileGroup(group))
+        await this.profilesService.writeProfileGroup(ProfilesSettingsTabComponent.collapsableIntoPartialProfileGroup(result))
         await this.config.save()
     }
 


### PR DESCRIPTION
Hey @Eugeny,

As discuss in #8912 and describe in #8925, my previous PR #8726 seems to have bring a new bug regarding the `Disable dynamic tab title` and `Clear terminal after connection` options (really sorry about that :/). At the time of the PR, I only notice this problem with the `group` attribute. I think we do not have other choice than deleting profile fields one by one in `writeProfile` method to prevent having ghost attributes in the profile config. 

Without deleting the field one by one, `Object.assign` call does not delete `undefinied` value from the profile object (Context from #8726):
> > What's the reason for `writeProfile` deleting the fields one by one? Is it so that default values get removed? That should already work automatically via ConfigProxy.

> When a profile is updated, the group attribute is set to `undefinied` if no group has been selected. Because of that, `Object.assign` do not seem to override the group attribute and leave the old value. It made impossible to reassign a profile in `Ungrouped`. But, now at head rested, I think this behavior only happens with the group attribute. It would probably be easier to change a bit the EditProfileModal to leave an empty string in the group attribute when no group has been selected.

Anyway, as we now provide profile object copy with `getProfileGroups`, profile field suppression can only be done inside `writeProfile` method. (related refactoring in e4169a54aa1686e928e81fd1391351304815407a)

I tried my best to describe what I found, I hope all of this is clear enough ^^'
Feel free to ask if any changes needed

Resolve #8925