### PR TITLE
Add Noctis colors plugin to themes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Plugins and themes can be installed directly from the Settings view inside Tabby
 * [gruvbox](https://github.com/porkloin/terminus-theme-gruvbox)
 * [windows10](https://www.npmjs.com/package/terminus-theme-windows10)
 * [altair](https://github.com/yxuko/terminus-altair)
-* [catppuccin](https://github.com/catppuccin/tabby) - Soothing pastel theme for Tabby 
+* [catppuccin](https://github.com/catppuccin/tabby) - Soothing pastel theme for Tabby
+* [noctis](https://github.com/aaronhuggins/tabby-colors-noctis) - color themes inspired by Noctis VS Code theme
 
 # Sponsors <!-- omit in toc -->
 


### PR DESCRIPTION
[Noctis](https://github.com/liviuschera/noctis) is my favorite set of themes for VS Code and I've been porting it over to other applications I use. I'm hoping others will appreciate these themes in Tabby as much as I have.