### PR TITLE
Fix: native modules rebuild on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
 
     - name: Install deps
       run: |
+        sudo -H pip install setuptools
         sudo npm i -g yarn@1.22.1 node-gyp@10
         yarn --network-timeout 1000000
       env:

--- a/scripts/build-linux.mjs
+++ b/scripts/build-linux.mjs
@@ -13,6 +13,7 @@ builder({
     armv7l: process.env.ARCH === 'armv7l',
     arm64: process.env.ARCH === 'arm64',
     config: {
+        npmRebuild: false,
         extraMetadata: {
             version: vars.version,
         },


### PR DESCRIPTION
Hi @Eugeny, I hope you're doing fine.

As describe in actions/runner#2958, node-gyp rebuild failed because of a missing dependency.
Adding `setuptools` pip module before building seems to fix this issue (https://github.com/Clem-Fern/tabby/actions/runs/6868200937).


