### PR TITLE
Win Portable: fix data directory and updater issue

### DIFF
--- a/app/lib/index.ts
+++ b/app/lib/index.ts
@@ -1,5 +1,8 @@
 import { app, ipcMain, Menu, dialog } from 'electron'
 
+// set userData Path on portable version
+import './portable'
+
 // set defaults of environment variables
 import 'dotenv/config'
 process.env.TABBY_PLUGINS ??= ''
@@ -7,7 +10,6 @@ process.env.TABBY_CONFIG_DIRECTORY ??= app.getPath('userData')
 
 
 import 'v8-compile-cache'
-import './portable'
 import 'source-map-support/register'
 import './sentry'
 import './lru'

--- a/tabby-electron/src/services/updater.service.ts
+++ b/tabby-electron/src/services/updater.service.ts
@@ -25,7 +25,7 @@ export class ElectronUpdaterService extends UpdaterService {
         super()
         this.logger = log.create('updater')
 
-        if (process.platform === 'linux') {
+        if (process.platform === 'linux' || process.env.PORTABLE_EXECUTABLE_FILE) {
             this.electronUpdaterAvailable = false
             return
         }


### PR DESCRIPTION
Hey @Eugeny,

2be079a51b6c668a217bdd7f77886f63e786763a: The new `TABBY_CONFIG_DIRECTORY` env var added in #6242 bypassed `data` folder on portable version.

1e096ede7785eca00da99eff7e96ab68590805ad: I added an exclusion for portable version in the updater service. Otherwise, the electron installer is used when an update is available.

Fix #9243
Fix #9148
Fix #7768