### PR TITLE
Fix#9262:  Jump host selection shows group id instead of group name

### DIFF
--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -67,7 +67,7 @@ export class SSHProfileSettingsComponent {
     }
 
     getJumpHostLabel (p: PartialProfile<SSHProfile>) {
-        return p.group ? `${p.group} / ${p.name}` : p.name
+        return p.group ? `${this.profilesService.resolveProfileGroupName(p.group)} / ${p.name}` : p.name
     }
 
     async setPassword () {

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -3,7 +3,7 @@ import { Component, ViewChild } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { firstBy } from 'thenby'
 
-import { ConfigService, FileProvidersService, Platform, HostAppService, PromptModalComponent, PartialProfile } from 'tabby-core'
+import { FileProvidersService, Platform, HostAppService, PromptModalComponent, PartialProfile, ProfilesService } from 'tabby-core'
 import { LoginScriptsSettingsComponent } from 'tabby-terminal'
 import { PasswordStorageService } from '../services/passwordStorage.service'
 import { ForwardedPortConfig, SSHAlgorithmType, SSHProfile } from '../api'
@@ -27,14 +27,14 @@ export class SSHProfileSettingsComponent {
 
     constructor (
         public hostApp: HostAppService,
-        private config: ConfigService,
+        private profilesService: ProfilesService,
         private passwordStorage: PasswordStorageService,
         private ngbModal: NgbModal,
         private fileProviders: FileProvidersService,
     ) { }
 
     async ngOnInit () {
-        this.jumpHosts = this.config.store.profiles.filter(x => x.type === 'ssh' && x !== this.profile)
+        this.jumpHosts = (await this.profilesService.getProfiles({ includeBuiltin: false })).filter(x => x.type === 'ssh' && x !== this.profile)
         this.jumpHosts.sort(firstBy(x => this.getJumpHostLabel(x)))
 
         for (const k of Object.values(SSHAlgorithmType)) {


### PR DESCRIPTION
Hey @Eugeny,


In ssh profile settings component:

3794081cef1024ece2db8516106c021132fbc9ec -> use `getProfiles` method from `ProfilesService` instead of accessing through `ConfigService` store.

f80db81857ec4f92c370f52dea5011baa34f240b -> resolve group name in `getJumpHostLabel` (Fix #9262)