### PR TITLE
add implicit CR and implicit LF for serial terminal similar to putty

### DIFF
--- a/locale/ko-KR.po
+++ b/locale/ko-KR.po
@@ -916,6 +916,14 @@ msgstr "CRLF 강제"
 msgid "Force LF"
 msgstr "LF 강제"
 
+#: tabby-terminal/src/components/streamProcessingSettings.component.ts:56
+msgid "Implicit CR in every LF"
+msgstr "LF에만 CR 추가"
+
+#: tabby-terminal/src/components/streamProcessingSettings.component.ts:57
+msgid "Implicit LF in every CR"
+msgstr "CR에만 LF 추가"
+
 #: locale/tmp-html/tabby-ssh/src/components/sshSettingsTab.component.html:25
 msgid "Forces a specific SSH agent connection type."
 msgstr "특정 SSH 에이전트로 연결 유형 강제"

--- a/tabby-terminal/src/components/streamProcessingSettings.component.ts
+++ b/tabby-terminal/src/components/streamProcessingSettings.component.ts
@@ -53,6 +53,8 @@ export class StreamProcessingSettingsComponent {
         { key: 'cr', name: _('Force CR') },
         { key: 'lf', name: _('Force LF') },
         { key: 'crlf', name: _('Force CRLF') },
+        { key: 'implicit_cr', name: _('Implicit CR in every LF') },
+        { key: 'implicit_lf', name: _('Implicit LF in every CR') },
     ]
 
     getInputModeName (key) {

--- a/tabby-terminal/src/middleware/streamProcessing.ts
+++ b/tabby-terminal/src/middleware/streamProcessing.ts
@@ -133,11 +133,9 @@ export class TerminalStreamProcessor extends SessionMiddleware {
     private replaceNewlines (data: Buffer, mode?: NewlineMode): Buffer {
         if (!mode) {
             return data
-        }
-        else if (mode == 'implicit_cr') {
+        } else if (mode === 'implicit_cr') {
             return bufferReplace(data, '\n', '\r\n')
-        }
-        else if (mode == 'implicit_lf') {
+        } else if (mode === 'implicit_lf') {
             return bufferReplace(data, '\r', '\r\n')
         }
 

--- a/tabby-terminal/src/middleware/streamProcessing.ts
+++ b/tabby-terminal/src/middleware/streamProcessing.ts
@@ -9,7 +9,7 @@ import { SessionMiddleware } from '../api/middleware'
 
 export type InputMode = null | 'local-echo' | 'readline' | 'readline-hex'
 export type OutputMode = null | 'hex'
-export type NewlineMode = null | 'cr' | 'lf' | 'crlf'
+export type NewlineMode = null | 'cr' | 'lf' | 'crlf' | 'implicit_cr' | 'implicit_lf'
 
 export interface StreamProcessingOptions {
     inputMode?: InputMode
@@ -134,6 +134,13 @@ export class TerminalStreamProcessor extends SessionMiddleware {
         if (!mode) {
             return data
         }
+        else if (mode == 'implicit_cr') {
+            return bufferReplace(data, '\n', '\r\n')
+        }
+        else if (mode == 'implicit_lf') {
+            return bufferReplace(data, '\r', '\r\n')
+        }
+
         data = bufferReplace(data, '\r\n', '\n')
         data = bufferReplace(data, '\r', '\n')
         const replacement = {


### PR DESCRIPTION
Hello,
Firstly, I've tried several terminal programs for serial connection, and I've found the tabby is really satisfying experience for me,
so thanks for the great development.

The one thing I missed from other programs is the "**Implicit CR in every LF**" and "**Implicit LF in every CR** features, which can be found in like putty.
That is, the tabby has a feature for "Force CRLF", but I want to add a CR only in LF, not adding LF in CR.

Therefore, this PR adds following two setting entries for new line modes in serial connection.
- Imiplicit CR: Only add CR in LF
- Implicit LF: Only add LF in CR