### PR TITLE
Add web-auth-handler to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Plugins and themes can be installed directly from the Settings view inside Tabby
 * [sftp-tab](https://github.com/wljince007/tabby-sftp-tab) - open sftp tab for ssh connection like SecureCRT
 * [background](https://github.com/moemoechu/tabby-background) - change Tabby background image and more...
 * [highlight](https://github.com/moemoechu/tabby-highlight) - Tabby terminal keyword highlight plugin
+* [web-auth-handler](https://github.com/Jazzmoon/tabby-web-auth-handler) - In-app web authentication popups (Built primarily for warpgate in-browser auth) 
 
 <a name="themes"></a>
 


### PR DESCRIPTION
This plugin aims to make using web authentication easier by intercepting the interactive keyboard prompt and opening the url in a popup window as a child to the main app 

Screenshot:
![image](https://github.com/Eugeny/tabby/assets/34384474/c0728f5b-e634-464d-8cf5-12e902bde06b)
