### PR TITLE
Add Support for a Quick Connect CLI command

### DIFF
--- a/app/lib/cli.ts
+++ b/app/lib/cli.ts
@@ -28,6 +28,16 @@ export function parseArgs (argv: string[], cwd: string): any {
         .command('recent [index]', 'open a tab with a recent profile', {
             profileNumber: { type: 'number' },
         })
+        .command('quickConnect <providerId> <query>', 'open a tab for specified quick connect provider', yargs => {
+            return yargs.positional('providerId', {
+                describe: 'The name of a quick connect profile provider',
+                type: 'string',
+                choices: ['ssh', 'telnet'],
+            }).positional('query', {
+                describe: 'The quick connect query string',
+                type: 'string',
+            })
+        })
         .version(app.getVersion())
         .option('debug', {
             alias: 'd',

--- a/tabby-core/src/cli.ts
+++ b/tabby-core/src/cli.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 import { HostAppService } from './api/hostApp'
 import { CLIHandler, CLIEvent } from './api/cli'
 import { HostWindowService } from './api/hostWindow'
+import { QuickConnectProfileProvider } from './api/profileProvider'
 import { ProfilesService } from './services/profiles.service'
 
 @Injectable()
@@ -27,6 +28,10 @@ export class ProfileCLIHandler extends CLIHandler {
             this.handleOpenRecentProfile(event.argv.profileNumber)
             return true
         }
+        if (op === 'quickConnect') {
+            this.handleOpenQuickConnect(event.argv.providerId, event.argv.query)
+            return true
+        }
         return false
     }
 
@@ -46,6 +51,21 @@ export class ProfileCLIHandler extends CLIHandler {
             return
         }
         this.profiles.openNewTabForProfile(profiles[profileNumber])
+        this.hostWindow.bringToFront()
+    }
+
+    private async handleOpenQuickConnect (providerId: string, query: string) {
+        const provider = this.profiles.getProviders().find(x => x.id === providerId)
+        if(!provider || !(provider instanceof QuickConnectProfileProvider)) {
+            console.error(`Requested provider "${providerId}" not found`)
+            return
+        }
+        const profile = provider.quickConnect(query)
+        if(!profile) {
+            console.error(`Could not parse quick connect query "${query}"`)
+            return
+        }
+        this.profiles.openNewTabForProfile(profile)
         this.hostWindow.bringToFront()
     }
 }


### PR DESCRIPTION
The goal of this PR is to introduce a new CLI command that enables launching an `ssh` or `telnet` connection in a new tab using the Profile Quick Connect query format.

Examples of utilizing the new command:

#### SSH
```bash
tabby quickConnect ssh 'bob@ssh-hostname.com:22'
```

#### Telnet
```bash
tabby quickConnect telnet '192.168.0.123:9000'
```