### PR TITLE
Fixed misspelled "Enable" as "Wyłącz" to "Włącz"

### DIFF
--- a/locale/pl-PL.po
+++ b/locale/pl-PL.po
@@ -745,7 +745,7 @@ msgstr "Włącz"
 #: locale/tmp-html/tabby-core/src/components/welcomeTab.component.html:32
 #: locale/tmp-html/tabby-settings/src/components/settingsTab.component.html:66
 msgid "Enable analytics"
-msgstr "Wyłącz Analitykę"
+msgstr "Włącz Analitykę"
 
 #: locale/tmp-html/tabby-settings/src/components/settingsTab.component.html:87
 msgid "Enable animations"


### PR DESCRIPTION
I noticed it after installing it on my Windows machine, someone misspelled it as "disable", it confuses.