### PR TITLE
electron-builder: remove gconf dependencies from deb package

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -76,8 +76,6 @@ snap:
   - system-observe
 deb:
   depends:
-  - gconf2
-  - gconf-service
   - gnome-keyring
   - libnotify4
   - libsecret-1-0


### PR DESCRIPTION
Hey @Eugeny, I hope you are doing well.

Gconf has been deprecated and is no longer available on new distro which make difficult to install Tabby. It's not very clear from electron-builder if `gconf2` and `gconf-service` are still needed in some case. docs(https://www.electron.build/configuration/linux.html#debian-package-options) say:
```
If need to support KDE, gconf2 and gconf-service should be removed as it’s no longer used by GNOME
```
PR updating the docs about this subject says:
```
gconf2 and gconf-service useless for KDE, package is for legacy applications and no longer used by GNOME.
```

Anyway, electron does not seem to depend on gconf since electron/electron#19498. if I haven't missed anything, it should be safe to remove theses two packages from deb dependencies.

Fix #9457 
Fix #9340 
Fix #9219 