### PR TITLE
Fix: Resolve SSH X11 Forwarding Repeated Handshake and Key Confirmation Issue

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -205,15 +205,15 @@ export class SSHSession {
         }
 
         const hostVerifiedPromise: Promise<void> = new Promise((resolve, reject) => {
-            let hostkey_old = ''
+            let hostkeyOld = ''
             let isKeyVerified = false
             ssh.on('handshake', async handshake => {
                 if (isKeyVerified) {
                     resolve()
                     return
                 }
-                if (hostkey_old !== handshake.serverHostKey) {
-                    hostkey_old = handshake.serverHostKey
+                if (hostkeyOld !== handshake.serverHostKey) {
+                    hostkeyOld = handshake.serverHostKey
                     if (!await this.verifyHostKey(handshake)) {
                         this.ssh.end()
                         reject(new Error('Host key verification failed'))

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -205,8 +205,8 @@ export class SSHSession {
         }
 
         const hostVerifiedPromise: Promise<void> = new Promise((resolve, reject) => {
-            let hostkey_old: string = ''
-            let isKeyVerified: boolean = false
+            let hostkey_old = ''
+            let isKeyVerified = false
             ssh.on('handshake', async handshake => {
                 if (isKeyVerified) {
                     resolve()

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -205,7 +205,7 @@ export class SSHSession {
         }
 
         const hostVerifiedPromise: Promise<void> = new Promise((resolve, reject) => {
-            let hostkey_old: string | undefined
+            let hostkey_old: string = ''
             let isKeyVerified: boolean = false
             ssh.on('handshake', async handshake => {
                 if (isKeyVerified) {


### PR DESCRIPTION
Bug Fix: When using SSH's X11 forwarding, or due to other internal uncertainties, there may be repeated handshakes and key confirmations between the client and the server.

Related Issue：
-  #8953
-  #8934

![image](https://github.com/Eugeny/tabby/assets/53071761/43bb5946-8315-4975-a048-8fbd9ca111a0)
