### PR TITLE
Make autoSync more robust for network errors

### DIFF
--- a/tabby-settings/src/services/configSync.service.ts
+++ b/tabby-settings/src/services/configSync.service.ts
@@ -194,7 +194,7 @@ export class ConfigSyncService {
                     }
                 }
             } catch (error) {
-                this.logger.debug("Recovering from autoSync network error")
+                this.logger.debug('Recovering from autoSync network error')
             }
             await new Promise(resolve => setTimeout(resolve, 60000))
         }

--- a/tabby-settings/src/services/configSync.service.ts
+++ b/tabby-settings/src/services/configSync.service.ts
@@ -184,13 +184,17 @@ export class ConfigSyncService {
 
     private async autoSync () {
         while (true) {
-            if (this.isEnabled() && this.config.store.configSync.auto) {
-                const cfg = await this.getConfig(this.config.store.configSync.configID)
-                if (new Date(cfg.modified_at) > this.lastRemoteChange) {
-                    this.logger.info('Remote config changed, downloading')
-                    this.download()
-                    this.lastRemoteChange = new Date(cfg.modified_at)
+            try {
+                if (this.isEnabled() && this.config.store.configSync.auto) {
+                    const cfg = await this.getConfig(this.config.store.configSync.configID)
+                    if (new Date(cfg.modified_at) > this.lastRemoteChange) {
+                        this.logger.info('Remote config changed, downloading')
+                        this.download()
+                        this.lastRemoteChange = new Date(cfg.modified_at)
+                    }
                 }
+            } catch (error) {
+                this.logger.debug("Recovering from autoSync network error")
             }
             await new Promise(resolve => setTimeout(resolve, 60000))
         }


### PR DESCRIPTION
Catch uncaught error in autoSync that caused autoSync to stop syncing after a network error occured. 
With this patch, syncing resumes normally after the network error is solved

Without the try{} catch:
```
22:43:12.678 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
22:43:12.712 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

22:44:12.714 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
22:44:12.747 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

22:45:12.751 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
22:45:12.786 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

22:46:12.792 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
22:46:12.826 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

22:47:12.838 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
22:47:12.845 [configSync] AxiosError {message: 'Network Error', name: 'AxiosError', code: 'ERR_NETWORK', config: {…}, request: XMLHttpRequest, …}
error_handler.ts:45 ERROR Error: Uncaught (in promise): AxiosError: Network Error
AxiosError: Network Error
    at XMLHttpRequest.handleError (C:\Workdir\MyApps\tabby-1.0.205-portable-x64\resources\builtin-plugins\tabby-settings\dist\index.js:13742:14)
    at XMLHttpRequest.sentryWrapped [as __zone_symbol__ON_PROPERTYerror] (helpers.ts:87:17)
    at XMLHttpRequest.wrapFn (zone.js:755:39)
    at _ZoneDelegate.invokeTask (zone.js:402:31)
    at Object.onInvokeTask (ng_zone.ts:408:29)
    at _ZoneDelegate.invokeTask (zone.js:401:60)
    at Zone.runTask (zone.js:171:47)
    at ZoneTask.invokeTask [as invoke] (zone.js:483:34)
    at invokeTask (zone.js:1631:18)
    at globalCallback (zone.js:1662:29)
    at XMLHttpRequest.globalZoneAwareCallback (zone.js:1695:16)
    at XMLHttpRequest.sentryWrapped (helpers.ts:87:17)
    at resolvePromise (zone.js:1193:31)
    at zone.js:1100:17
    at zone.js:1116:33
    at rejected (C:\Workdir\MyApps\tabby-1.0.205-portable-x64\resources\builtin-plugins\tabby-settings\dist\index.js:6196:9)
    at _ZoneDelegate.invoke (zone.js:368:26)
    at Object.onInvoke (ng_zone.ts:423:29)
    at _ZoneDelegate.invoke (zone.js:367:52)
    at Zone.run (zone.js:127:43)
    at zone.js:1257:36
    at _ZoneDelegate.invokeTask (zone.js:402:31)
    at Object.onInvokeTask (ng_zone.ts:408:29)
    at _ZoneDelegate.invokeTask (zone.js:401:60)
    at Zone.runTask (zone.js:171:47)
    at drainMicroTaskQueue (zone.js:581:35)
    at ZoneTask.invokeTask [as invoke] (zone.js:487:21)
    at invokeTask (zone.js:1631:18)
    at globalCallback (zone.js:1662:29)
    at XMLHttpRequest.globalZoneAwareCallback (zone.js:1695:16)
    at XMLHttpRequest.sentryWrapped (helpers.ts:87:17)
22:47:12.850 trycatch.ts:281  GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** net::ERR_NAME_NOT_RESOLVED
```
Syncing stops after this.


With the try{} catch, the syncing continues like normal after a network error:
```
23:17:42.574 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:17:42.608 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

23:18:42.621 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:18:42.655 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

23:19:42.667 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:19:42.704 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}

23:20:42.711 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:20:42.719 [configSync] AxiosError {message: 'Network Error', name: 'AxiosError', code: 'ERR_NETWORK', config: {…}, request: XMLHttpRequest, …}
23:20:42.723 [configSync] Recovering from autoSync network error
23:20:42.724 trycatch.ts:281 GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** net::ERR_NAME_NOT_RESOLVED

23:21:42.738 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:21:42.745 [configSync] AxiosError {message: 'Network Error', name: 'AxiosError', code: 'ERR_NETWORK', config: {…}, request: XMLHttpRequest, …}
23:21:42.749 [configSync] Recovering from autoSync network error
23:21:42.750 trycatch.ts:281 GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** net::ERR_NAME_NOT_RESOLVED

23:22:42.760 [configSync] GET https://tabby-sync.**redacted-domainname**/werklaptop/api/1/configs/**redacted-sync-token** {}
23:22:42.848 [configSync] {data: {…}, status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}
```