### PR TITLE
docs(hacking): adds clarification for installing forks

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -23,6 +23,8 @@ sudo apt install libfontconfig-dev libsecret-1-dev libarchive-tools libnss3 liba
 yarn
 ```
 
+_⚠️Note: If you forked this repository, you may need to pull down the tags from this repository before installing node modules. `git pull --tags upstream master`_
+
 Build Tabby:
 
 ```


### PR DESCRIPTION
In attempting to get things running locally to debug #8957, I ran into an error that was unintuitive to resolve because `yarn` is usually agnostic of git.  I don't have the screenshot, but the solution was to pull the tags from the repo.  This PR adds a note about that.