### PR TITLE
wsl: Get the distro icon from the package family name

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "electron-updater": "^5.2.1",
     "fontmanager-redux": "1.1.0",
     "glasstron": "0.1.1",
+    "node-powershell": "5.0.1",
     "js-yaml": "4.1.0",
     "keytar": "^7.9.0",
     "mz": "^2.7.0",

--- a/tabby-core/src/components/profileIcon.component.pug
+++ b/tabby-core/src/components/profileIcon.component.pug
@@ -1,7 +1,11 @@
+.icon(
+    [fastHtmlBind]='pngPath',
+    *ngIf='!isHTML && isPNG'
+)
 i.icon(
     class='fa-fw {{icon}}',
     [style.color]='color',
-    *ngIf='!isHTML'
+    *ngIf='!isHTML && !isPNG'
 )
 .icon(
     [fastHtmlBind]='icon',

--- a/tabby-core/src/components/profileIcon.component.ts
+++ b/tabby-core/src/components/profileIcon.component.ts
@@ -12,7 +12,15 @@ export class ProfileIconComponent extends BaseComponent {
     @Input() icon?: string
     @Input() color?: string
 
+    get pngPath (): string {
+        return `<img src="${this.icon?.trim()}" width="16" height="16" />`
+    }
+
     get isHTML (): boolean {
         return this.icon?.startsWith('<') ?? false
+    }
+
+    get isPNG (): boolean {
+        return this.icon?.endsWith('.png') ?? false
     }
 }


### PR DESCRIPTION
All the WSL distributions installed from the Microsoft Store have a package family name that can be used to get the distribution icon.

For example, this way even distributions that are not in the Tabby SVG list can show the distro icon:

![image](https://github.com/Eugeny/tabby/assets/2633321/113f218d-8c73-41fb-b380-61d34100d716)
