### PR TITLE
Fix Issue #8461: Add Toggle Hotkey and Pin Button for SFTP Panel

### DIFF
--- a/tabby-core/src/hotkeys.ts
+++ b/tabby-core/src/hotkeys.ts
@@ -255,6 +255,10 @@ export class AppHotkeyProvider extends HotkeyProvider {
             id: 'pane-decrease-horizontal',
             name: this.translate.instant('Decrease horizontal split size'),
         },
+        {
+            id: 'open-sftp-pane',
+            name: this.translate.instant('Open SFTP panel'),
+        }
     ]
 
     constructor (

--- a/tabby-core/src/hotkeys.ts
+++ b/tabby-core/src/hotkeys.ts
@@ -256,8 +256,8 @@ export class AppHotkeyProvider extends HotkeyProvider {
             name: this.translate.instant('Decrease horizontal split size'),
         },
         {
-            id: 'open-sftp-pane',
-            name: this.translate.instant('Open SFTP panel'),
+            id: 'toggle-sftp-pane',
+            name: this.translate.instant('Toggle SFTP panel'),
         }
     ]
 

--- a/tabby-ssh/src/components/sftpPanel.component.pug
+++ b/tabby-ssh/src/components/sftpPanel.component.pug
@@ -24,6 +24,11 @@
     button.btn.btn-link.btn-sm.flex-shrink-0.d-flex((click)='upload()')
         i.fas.fa-upload.me-1
         div(translate) Upload
+    
+    button.btn.btn-link.btn-sm.flex-shrink-0.d-flex((click)='togglePinSFTPPanel()')
+        i.fas.fa-thumbtack
+        span(*ngIf='pinSFTPPanel', translate) Unpin
+        span(*ngIf='!pinSFTPPanel', translate) Pin
 
     button.btn.btn-link.text-decoration-none((click)='close()') !{require('../../../tabby-core/src/icons/times.svg')}
 

--- a/tabby-ssh/src/components/sftpPanel.component.ts
+++ b/tabby-ssh/src/components/sftpPanel.component.ts
@@ -1,6 +1,6 @@
 import * as C from 'constants'
 import { posix as path } from 'path'
-import { Component, Input, Output, EventEmitter, Inject, Optional } from '@angular/core'
+import { Component, Input, Output, EventEmitter, Inject, Optional, HostBinding } from '@angular/core'
 import { FileUpload, MenuItemOptions, NotificationsService, PlatformService } from 'tabby-core'
 import { SFTPSession, SFTPFile } from '../session/sftp'
 import { SSHSession } from '../session/ssh'
@@ -28,6 +28,8 @@ export class SFTPPanelComponent {
     pathSegments: PathSegment[] = []
     @Input() cwdDetectionAvailable = false
     editingPath: string|null = null
+    @HostBinding('class.pinned') pinSFTPPanel = false
+    @Output() pinStateChange = new EventEmitter<boolean>()
 
     constructor (
         private ngbModal: NgbModal,
@@ -244,6 +246,11 @@ export class SFTPPanelComponent {
         }
         this.navigate(this.editingPath)
         this.editingPath = null
+    }
+
+    togglePinSFTPPanel() {
+        this.pinSFTPPanel = !this.pinSFTPPanel;
+        this.pinStateChange.emit(this.pinSFTPPanel);
     }
 
     close (): void {

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -58,6 +58,9 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
                 case 'restart-ssh-session':
                     this.reconnect()
                     break
+                case 'open-sftp-pane':
+                    this.openSFTP()
+                    break
                 case 'launch-winscp':
                     if (this.sshSession) {
                         this.ssh.launchWinSCP(this.sshSession)

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -1,6 +1,6 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import colors from 'ansi-colors'
-import { Component, Injector, HostListener } from '@angular/core'
+import { Component, Injector, HostListener, ViewChild } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { Platform, ProfilesService } from 'tabby-core'
 import { BaseTerminalTabComponent, ConnectableTerminalTabComponent } from 'tabby-terminal'
@@ -10,6 +10,7 @@ import { SSHPortForwardingModalComponent } from './sshPortForwardingModal.compon
 import { SSHProfile } from '../api'
 import { SSHShellSession } from '../session/shell'
 import { SSHMultiplexerService } from '../services/sshMultiplexer.service'
+import { SFTPPanelComponent } from './sftpPanel.component'
 
 /** @hidden */
 @Component({
@@ -26,9 +27,11 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
     sshSession: SSHSession|null = null
     session: SSHShellSession|null = null
     sftpPanelVisible = false
+    isSftpPanelPinned = false;
     sftpPath = '/'
     enableToolbar = true
     activeKIPrompt: KeyboardInteractivePrompt|null = null
+    @ViewChild(SFTPPanelComponent, { static: false }) sftpPanel: SFTPPanelComponent;
 
     constructor (
         injector: Injector,
@@ -220,9 +223,26 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
         }, 100)
     }
 
+    ngAfterViewChecked() {
+        if (this.sftpPanel && !this.sftpPanel.pinStateChange.observers.length) {
+            this.subscribeToPinState();
+        }
+    }
+
+    subscribeToPinState() {
+        this.sftpPanel.pinStateChange.subscribe((isPinned: boolean) => {
+            this.isSftpPanelPinned = isPinned;
+        });
+        this.sftpPanel.closed.subscribe(() => {
+            this.isSftpPanelPinned = false;
+        });
+    }
+
     @HostListener('click')
-    onClick (): void {
-        this.sftpPanelVisible = false
+    onClick(): void {
+        if (!this.isSftpPanelPinned) {
+            this.sftpPanelVisible = false;
+        }
     }
 
     protected isSessionExplicitlyTerminated (): boolean {

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -58,8 +58,12 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
                 case 'restart-ssh-session':
                     this.reconnect()
                     break
-                case 'open-sftp-pane':
-                    this.openSFTP()
+                case 'toggle-sftp-pane':
+                    if (this.sftpPanelVisible) {
+                        this.sftpPanelVisible = false
+                    } else {
+                        this.openSFTP()
+                    }
                     break
                 case 'launch-winscp':
                     if (this.sshSession) {


### PR DESCRIPTION
This PR addresses Issue #8461 by introducing two new features for the SFTP Panel:

1. Toggle Hotkey:

- Added a hotkey to toggle the visibility of the SFTP Panel, enhancing user convenience.
![Hotkey](https://github.com/user-attachments/assets/5a6a4edd-5031-4702-8901-1895f78ceba8)

2. Pin Button:

- Introduced a Pin button in the SFTP Panel. When activated, this button prevents the panel from closing when clicking outside of it, ensuring that the pinned panel remains open.
![Pin](https://github.com/user-attachments/assets/718b1d1a-2ea5-4ce6-a576-283ca1cd250f)