### PR TITLE
Fixed the issue where Windows Vibrancy was not working on newer versions of macOS due to the outdated macos-release package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "html-loader": "4.2.0",
     "json-loader": "^0.5.7",
     "lru-cache": "^6.0.0",
-    "macos-release": "^3.1.0",
+    "macos-release": "^3.3.0",
     "ngx-toastr": "^16.0.2",
     "node-abi": "^3.65.0",
     "npmlog": "6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5623,10 +5623,10 @@ lzma-native@^8.0.5, lzma-native@^8.0.6:
     node-gyp-build "^4.2.1"
     readable-stream "^3.6.0"
 
-macos-release@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.1.0.tgz#6165bb0736ae567ed6649e36ce6a24d87cbb7aca"
-  integrity sha512-/M/R0gCDgM+Cv1IuBG1XGdfTFnMEG6PZeT+KGWHO/OG+imqmaD9CH5vHBTycEM3+Kc4uG2Il+tFAuUWLqQOeUA==
+macos-release@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.3.0.tgz#92cb67bc66d67c3fde4a9e14f5f909afa418b072"
+  integrity sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==
 
 magic-string@^0.27.0:
   version "0.27.0"


### PR DESCRIPTION
Hi, 

In current latest version, window vibrancy option in macOS is broken, as mentioned in issue #9389 

After some investigation, I've found the root cause: the version of the macos-release package being used is 3.1.0, which does not support macOS 14. 

As a result, on macOS 14, the `macOSRelease().version` in `app/lib/windows.ts` always returns an empty string, causing the macOSVibrancyType variable to always default to `'dark'` (which has been deprecated in newer versions of macOS) instead of the intended `'under-window'`. 

This ultimately leads to the failure of the `Settings/Window/Vibrancy` option (the background remains totally opaque). 

Updating the macos-release package to the latest version will return the correct system version and resolve this issue.

The attachment shows a comparison before and after the modifications. The NSVisualEffectView used by Electron has relatively high opacity, making the effect less noticeable, but upon close inspection, the difference can be seen.


There seems to be another issue: the `Vibrancy` and `Opaque` options seem to conflict with each other on macOS 14. 

The `Vibrancy` option only takes effect when the `Opaque` option is set to full.

<img width="1223" alt="截屏2024-08-22 22 20 45" src="https://github.com/user-attachments/assets/d6a88943-6cd6-4a7c-aebc-4a43e094c770">
<img width="1222" alt="截屏2024-08-22 22 20 20" src="https://github.com/user-attachments/assets/2ba39735-03b2-4312-b928-c6305b6cd4ef">
