### PR TITLE
Modify the NSVisualEffectView material in app/lib/window.ts to "fullscreen-ui" on macOS to achieve a more glass-like effect.

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -26,7 +26,7 @@ abstract class GlasstronWindow extends BrowserWindow {
     abstract setBlur (_: boolean)
 }
 
-const macOSVibrancyType: any = process.platform === 'darwin' ? compareVersions(macOSRelease().version || '0.0', '10.14', '>=') ? 'under-window' : 'dark' : null
+const macOSVibrancyType: any = process.platform === 'darwin' ? compareVersions(macOSRelease().version || '0.0', '10.14', '>=') ? 'fullscreen-ui' : 'dark' : null
 
 const activityIcon = nativeImage.createFromPath(`${app.getAppPath()}/assets/activity.png`)
 


### PR DESCRIPTION
Hi,

Yesterday, I was tinkering around the `Window/Vibrancy` setting, and it did bring back some of the frosted glass effect on macOS.

Today, I discovered that changing the underlying NSVisualEffectView material to `fullscreen-ui` seems to make it slightly more transparent than the previous `under-window` setting. 

Personally, I think it looks better. Here's a comparison. (May we can have a setting for this?)


<img width="1222" alt="截屏2024-08-23 18 16 36" src="https://github.com/user-attachments/assets/4ff6d1e8-2d81-4744-b166-9ad565cb6b77">


<img width="1222" alt="截屏2024-08-23 18 13 37" src="https://github.com/user-attachments/assets/0a244219-9021-45bd-98c6-3d66d5ef86ba">
