### PR TITLE
Update packagecloud action with up2date distro versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,13 +233,15 @@ jobs:
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
     - name: Upload packages to packagecloud.io
-      uses: Eugeny/packagecloud-action@main
+      uses: TykTechnologies/packagecloud-action@main
       if: github.repository == 'Eugeny/tabby' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       env:
         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       with:
         repo: 'eugeny/tabby'
         dir: 'dist'
+        rpmvers: 'el/9 el/8 ol/6 ol/7'
+        debvers: 'ubuntu/noble ubuntu/jammy ubuntu/focal ubuntu/bionic debian/jessie debian/stretch debian/buster'
 
     - uses: actions/upload-artifact@master
       name: Upload AppImage (${{matrix.arch}})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
         repo: 'eugeny/tabby'
         dir: 'dist'
         rpmvers: 'el/9 el/8 ol/6 ol/7'
-        debvers: 'ubuntu/noble ubuntu/jammy ubuntu/focal ubuntu/bionic debian/jessie debian/stretch debian/buster'
+        debvers: 'ubuntu/bionic ubuntu/focal ubuntu/hirsute ubuntu/impish ubuntu/jammy ubuntu/kinetic ubuntu/noble debian/jessie debian/stretch debian/buster'
 
     - uses: actions/upload-artifact@master
       name: Upload AppImage (${{matrix.arch}})


### PR DESCRIPTION
Fixes #9864. Switch to external action which now supports setting rpmvers and debvers. I took the settings in Eugeny/packagecloud-action and updated them by the newly released ones.