### PR TITLE
Fix#9323: Can't modify profiles created via "Save as profile"

### DIFF
--- a/tabby-core/src/services/config.service.ts
+++ b/tabby-core/src/services/config.service.ts
@@ -102,6 +102,10 @@ export class ConfigProxy {
                 }
             }
         }
+
+        this.__getReal = () => { // eslint-disable-line @typescript-eslint/unbound-method
+            return real
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function
@@ -112,6 +116,8 @@ export class ConfigProxy {
     __getDefault (_key: string): any { }
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function
     __cleanup () { }
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function
+    __getReal (): any { }
 }
 
 @Injectable({ providedIn: 'root' })

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -66,9 +66,9 @@ export class ProfilesService {
     * arg: skipUserDefaults -> do not merge global provider defaults in ConfigProxy
     * arg: skipGroupDefaults -> do not merge parent group provider defaults in ConfigProxy
     */
-    getConfigProxyForProfile <T extends Profile> (profile: PartialProfile<T>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): T {
+    getConfigProxyForProfile <T extends Profile> (profile: PartialProfile<T>, options?: { skipGlobalDefaults?: boolean, skipGroupDefaults?: boolean }): T & ConfigProxy {
         const defaults = this.getProfileDefaults(profile, options).reduce(configMerge, {})
-        return new ConfigProxy(profile, defaults) as unknown as T
+        return new ConfigProxy(profile, defaults) as unknown as T & ConfigProxy
     }
 
     /**

--- a/tabby-terminal/src/tabContextMenu.ts
+++ b/tabby-terminal/src/tabContextMenu.ts
@@ -180,7 +180,7 @@ export class SaveAsProfileContextMenu extends TabContextMenuItemProvider {
                         }
 
                         const tab_options = tab.profile.options instanceof ConfigProxy ? (tab.profile.options as ConfigProxy).__getReal() : tab.profile.options
-                        const options = {...tab_options}
+                        const options = { ...tab_options }
 
                         const cwd = await tab.session?.getWorkingDirectory() ?? tab.profile.options.cwd
                         if (cwd) {


### PR DESCRIPTION
Hey @Eugeny 

This PR aims to fix #9323. The issue is caused by `tab.profile.options` being a reference to a `ConfigProxy` instance in some case.

```
error_handler.ts:45 ERROR TypeError: Cannot delete property 'hmac' of [object Object]
    at ConfigProxy.__setValue (/opt/Tabby/resources/builtin-plugins/tabby-core/dist/index.js:20266:29)
    at ConfigProxy.set [as hmac] (/opt/Tabby/resources/builtin-plugins/tabby-core/dist/index.js:20241:30)
    at SSHProfileSettingsComponent.save (/opt/Tabby/resources/builtin-plugins/tabby-ssh/dist/index.js:7553:48)
    at EditProfileModalComponent.save (/opt/Tabby/resources/builtin-plugins/tabby-settings/dist/index.js:7167:139)
    at EditProfileModalComponent_Template_button_click_37_listener (template.html:70:44)
    at executeListenerWithErrorHandling (listener.ts:224:12)
    at wrapListenerIn_markDirtyAndPreventDefault (listener.ts:261:18)
    at HTMLButtonElement.<anonymous> (dom_renderer.ts:76:34)
    at _ZoneDelegate.invokeTask (zone.js:402:31)
    at Object.onInvokeTask (ng_zone.ts:408:29)
    at _ZoneDelegate.invokeTask (zone.js:401:60)
    at Zone.runTask (zone.js:171:47)
    at ZoneTask.invokeTask [as invoke] (zone.js:483:34)
    at invokeTask (zone.js:1631:18)
    at globalCallback (zone.js:1662:29)
    at HTMLButtonElement.globalZoneAwareCallback (zone.js:1695:16)
    at HTMLButtonElement.sentryWrapped (helpers.ts:87:17)
```

With this fix, options real instance is retrieved before cloning it. Newly saved profile is then cleaned up from any remaining default options before being added into profiles.

Fix #9323 