### PR TITLE
Feat#10008: add hotkeys to open profile selectors for a specific group

### DIFF
--- a/tabby-core/src/configDefaults.yaml
+++ b/tabby-core/src/configDefaults.yaml
@@ -31,6 +31,8 @@ hotkeys:
     __nonStructural: true
   profile-selectors:
     __nonStructural: true
+  group-selectors:
+    __nonStructural: true
 profiles: []
 groups: []
 profileDefaults:

--- a/tabby-core/src/hotkeys.ts
+++ b/tabby-core/src/hotkeys.ts
@@ -264,6 +264,7 @@ export class AppHotkeyProvider extends HotkeyProvider {
 
     async provide (): Promise<HotkeyDescription[]> {
         const profiles = await this.profilesService.getProfiles()
+        const groups = await this.profilesService.getProfileGroups()
         return [
             ...this.hotkeys,
             ...profiles.map(profile => ({
@@ -273,6 +274,10 @@ export class AppHotkeyProvider extends HotkeyProvider {
             ...this.profilesService.getProviders().map(provider => ({
                 id: `profile-selectors.${provider.id}`,
                 name: this.translate.instant('Show {type} profile selector', { type: provider.name }),
+            })),
+            ...groups.map(group => ({
+                id: `group-selectors.${group.id}`,
+                name: this.translate.instant('Show profile selector for group {name}', { name: group.name }),
             })),
         ]
     }

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -487,6 +487,12 @@ export class ProfilesService {
                 delete profile.group
             }
         }
+        if (this.config.store.hotkeys['group-selectors'].hasOwnProperty(group.id)) {
+            const groupSelectorsHotkeys = { ...this.config.store.hotkeys['group-selectors'] }
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete groupSelectorsHotkeys[group.id]
+            this.config.store.hotkeys['group-selectors'] = groupSelectorsHotkeys
+        }
     }
 
     /**


### PR DESCRIPTION
Close #10008: Add hotkeys to open profile selectors for a specific group.

![image](https://github.com/user-attachments/assets/b1fc2be0-03e9-465d-9286-e6388efba6af)
![image](https://github.com/user-attachments/assets/55fda854-a904-4dfb-a01f-1922b24cf435)
