### PR TITLE
Using ssh default profile(user/password) without host to access multiple servers

### DIFF
--- a/tabby-core/src/services/vault.service.ts
+++ b/tabby-core/src/services/vault.service.ts
@@ -195,7 +195,13 @@ export class VaultService {
         if (!vault) {
             return null
         }
-        return vault.secrets.find(s => s.type === type && this.keyMatches(key, s)) ?? null
+        let vaultSecret = vault.secrets.find(s => s.type === type && this.keyMatches(key, s))
+        if (!vaultSecret) {
+            // search for secret without host in vault (like a default user/password used in multiple servers)
+            key['host'] = null
+            vaultSecret = vault.secrets.find(s => s.type === type && this.keyMatches(key, s))
+        }
+        return vaultSecret ?? null
     }
 
     async addSecret (secret: VaultSecret): Promise<void> {


### PR DESCRIPTION
**Issue** 
Connecting with SSH to multiple servers that have centralized authentication (same user/password) forces us to save this password in all the profiles (hosts) of our vault, making password changes tedious.
Closes #10077, resolves #6156, resolves #9305, closes #9669

**Solution** 
Now we can use a default profile to create a user/password without specifying the host in the vault. It will be used by default if there's no other entry in the vault with the host we want to connect to.
<img width="309" alt="image" src="https://github.com/user-attachments/assets/1658d40b-5856-418e-946a-b7868fbf3b9e">
