### PR TITLE
Set the application's dark mode to follow the app settings on macOS.

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -1,7 +1,7 @@
 import * as glasstron from 'glasstron'
 import { autoUpdater } from 'electron-updater'
 import { Subject, Observable, debounceTime } from 'rxjs'
-import { BrowserWindow, app, ipcMain, Rectangle, Menu, screen, BrowserWindowConstructorOptions, TouchBar, nativeImage, WebContents } from 'electron'
+import { BrowserWindow, app, ipcMain, Rectangle, Menu, screen, BrowserWindowConstructorOptions, TouchBar, nativeImage, WebContents, nativeTheme } from 'electron'
 import ElectronConfig = require('electron-config')
 import { enable as enableRemote } from '@electron/remote/main'
 import * as os from 'os'
@@ -115,6 +115,8 @@ export class Window {
                 this.setVibrancy(true)
             }
 
+            this.setDarkMode(this.configStore.appearance?.colorSchemeMode ?? 'dark')
+
             if (!options.hidden) {
                 if (maximized) {
                     this.window.maximize()
@@ -198,6 +200,18 @@ export class Window {
             this.window.setBlur(enabled)
         } else {
             this.window.setVibrancy(enabled ? macOSVibrancyType : null)
+        }
+    }
+
+    setDarkMode (mode: string): void {
+        if (process.platform === 'darwin') {
+            if ('light' === mode ) {
+                nativeTheme.themeSource = 'light'
+            } else if ('auto' === mode) {
+                nativeTheme.themeSource = 'system'
+            } else {
+                nativeTheme.themeSource = 'dark'
+            }
         }
     }
 
@@ -371,6 +385,10 @@ export class Window {
 
         this.on('window-set-vibrancy', (_, enabled, type) => {
             this.setVibrancy(enabled, type)
+        })
+
+        this.on('window-set-dark-mode', (_, mode) => {
+            this.setDarkMode(mode)
         })
 
         this.on('window-set-window-controls-color', (_, theme) => {

--- a/tabby-electron/src/index.ts
+++ b/tabby-electron/src/index.ts
@@ -177,7 +177,7 @@ export default class ElectronModule {
     }
 
     private updateDarkMode () {
-        let colorSchemeMode = this.config.store.appearance.colorSchemeMode
+        const colorSchemeMode = this.config.store.appearance.colorSchemeMode
         this.electron.ipcRenderer.send('window-set-dark-mode', colorSchemeMode)
     }
 

--- a/tabby-electron/src/index.ts
+++ b/tabby-electron/src/index.ts
@@ -130,7 +130,10 @@ export default class ElectronModule {
             })
         })
 
-        config.changed$.subscribe(() => this.updateVibrancy())
+        config.changed$.subscribe(() => {
+            this.updateVibrancy()
+            this.updateDarkMode()
+        })
 
         config.changed$.subscribe(() => this.updateWindowControlsColor())
 
@@ -171,6 +174,11 @@ export default class ElectronModule {
         this.electron.ipcRenderer.send('window-set-vibrancy', this.config.store.appearance.vibrancy, vibrancyType)
 
         this.hostWindow.setOpacity(this.config.store.appearance.opacity)
+    }
+
+    private updateDarkMode () {
+        let colorSchemeMode = this.config.store.appearance.colorSchemeMode
+        this.electron.ipcRenderer.send('window-set-dark-mode', colorSchemeMode)
     }
 
     private updateWindowControlsColor () {


### PR DESCRIPTION
Hi, 

This pull request is a continuation of #10177 

Your **elegant** solution completely eliminates the need to modify colorSchemeSettingsTab.component.ts/pug👍 👍 

You’re amazing!

To avoid unnecessary back-and-forth changes to these two files, I’ve followed your instructions and made the adjustments. This new pull request reflects those updates.

Thanks again for your guidance!