### PR TITLE
Keep the translucency effect even when the window loses focus on macOS.

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -101,6 +101,10 @@ export class Window {
         }
 
         if (process.platform === 'darwin') {
+            bwOptions.visualEffectState = 'active'
+        }
+
+        if (process.platform === 'darwin') {
             this.window = new BrowserWindow(bwOptions) as GlasstronWindow
         } else {
             this.window = new glasstron.BrowserWindow(bwOptions)


### PR DESCRIPTION
Hi,

Changed a small configuration on macOS, so the window will remain translucent even it loses focus.

I think it might look better?

<img width="1292" alt="截屏2025-01-13 18 16 03" src="https://github.com/user-attachments/assets/9e00cee5-36bf-441d-a5e4-6d9cc2694c1b" />

<img width="1265" alt="截屏2025-01-13 18 16 26" src="https://github.com/user-attachments/assets/e82ee290-c118-4379-8a6a-3f06fa618e64" />

Sorry, I’m not very familiar with Electron, so I end up modifying just a tiny little part of the code each time to fix an issue I find while using Tabby. lol

Thank you!