### PR TITLE
Add Tokyonight color scheme

### DIFF
--- a/tabby-community-color-schemes/schemes/TokyoNight
+++ b/tabby-community-color-schemes/schemes/TokyoNight
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xreources.py
+!
+*.foreground:  #c0caf5
+*.background:  #1a1b26
+*.cursorColor: #c0caf5
+!
+! Black
+*.color0:      #15161e
+*.color8:      #414868
+!
+! Red
+*.color1:      #f7768e
+*.color9:      #f7768e
+!
+! Green
+*.color2:      #9ece6a
+*.color10:     #9ece6a
+!
+! Yellow
+*.color3:      #e0af68
+*.color11:     #e0af68
+!
+! Blue
+*.color4:      #7aa2f7
+*.color12:     #7aa2f7
+!
+! Magenta
+*.color5:      #bb9af7
+*.color13:     #bb9af7
+!
+! Cyan
+*.color6:      #7dcfff
+*.color14:     #7dcfff
+!
+! White
+*.color7:      #a9b1d6
+*.color15:     #c0caf5
+!
+! Bold, Italic, Underline
+*.colorBD:     #eeeeee
+!*.colorIT:
+!*.colorUL:

--- a/tabby-community-color-schemes/schemes/TokyoNight Day
+++ b/tabby-community-color-schemes/schemes/TokyoNight Day
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xreources.py
+!
+*.foreground:  #3760bf
+*.background:  #e1e2e7
+*.cursorColor: #3760bf
+!
+! Black
+*.color0:      #e9e9ed
+*.color8:      #a1a6c5
+!
+! Red
+*.color1:      #f52a65
+*.color9:      #f52a65
+!
+! Green
+*.color2:      #587539
+*.color10:     #587539
+!
+! Yellow
+*.color3:      #8c6c3e
+*.color11:     #8c6c3e
+!
+! Blue
+*.color4:      #2e7de9
+*.color12:     #2e7de9
+!
+! Magenta
+*.color5:      #9854f1
+*.color13:     #9854f1
+!
+! Cyan
+*.color6:      #007197
+*.color14:     #007197
+!
+! White
+*.color7:      #6172b0
+*.color15:     #3760bf
+!
+! Bold, Italic, Underline
+*.colorBD:     #eeeeee
+!*.colorIT:
+!*.colorUL:

--- a/tabby-community-color-schemes/schemes/TokyoNight Storm
+++ b/tabby-community-color-schemes/schemes/TokyoNight Storm
@@ -1,0 +1,44 @@
+!
+! Generated with :
+! XRDB2Xreources.py
+!
+*.foreground:  #c0caf5
+*.background:  #24283b
+*.cursorColor: #c0caf5
+!
+! Black
+*.color0:      #1d202f
+*.color8:      #414868
+!
+! Red
+*.color1:      #f7768e
+*.color9:      #f7768e
+!
+! Green
+*.color2:      #9ece6a
+*.color10:     #9ece6a
+!
+! Yellow
+*.color3:      #e0af68
+*.color11:     #e0af68
+!
+! Blue
+*.color4:      #7aa2f7
+*.color12:     #7aa2f7
+!
+! Magenta
+*.color5:      #bb9af7
+*.color13:     #bb9af7
+!
+! Cyan
+*.color6:      #7dcfff
+*.color14:     #7dcfff
+!
+! White
+*.color7:      #a9b1d6
+*.color15:     #c0caf5
+!
+! Bold, Italic, Underline
+*.colorBD:     #eeeeee
+!*.colorIT:
+!*.colorUL:


### PR DESCRIPTION
This PR adds the **Tokyonight** color scheme (TokyoNight, TokyoNight Day and TokyoNight Storm), originally from the [terminal-color-schemes](https://github.com/jenny-codes/terminal-color-schemes/tree/master) repository. 
The theme has been integrated and adapted for our project.

Theme: Tokyonight
