### PR TITLE
Fix: Unable to launch WinSCP for SSH sessions using private key

### DIFF
--- a/tabby-ssh/src/services/ssh.service.ts
+++ b/tabby-ssh/src/services/ssh.service.ts
@@ -1,7 +1,8 @@
-// import * as fs from 'fs/promises'
+import * as fs from 'fs/promises'
+import * as crypto from 'crypto'
 import * as tmp from 'tmp-promise'
 import { Injectable } from '@angular/core'
-import { ConfigService, HostAppService, Platform, PlatformService } from 'tabby-core'
+import { ConfigService, FileProvidersService, HostAppService, Platform, PlatformService } from 'tabby-core'
 import { SSHSession } from '../session/ssh'
 import { SSHProfile } from '../api'
 import { PasswordStorageService } from './passwordStorage.service'
@@ -15,6 +16,7 @@ export class SSHService {
         private config: ConfigService,
         hostApp: HostAppService,
         private platform: PlatformService,
+        private fileProviders: FileProvidersService,
     ) {
         if (hostApp.platform === Platform.Windows) {
             this.detectedWinSCPPath = platform.getWinSCPPath()
@@ -47,14 +49,38 @@ export class SSHService {
         const args = [await this.getWinSCPURI(session.profile, undefined, session.authUsername ?? undefined)]
 
         let tmpFile: tmp.FileResult|null = null
-        if (session.activePrivateKey) {
-            tmpFile = await tmp.file()
-            // await fs.writeFile(tmpFile.path, session.activePrivateKey)
-            const winSCPcom = path.slice(0, -3) + 'com'
-            await this.platform.exec(winSCPcom, ['/keygen', tmpFile.path, `/output=${tmpFile.path}`])
-            args.push(`/privatekey=${tmpFile.path}`)
+        try {
+            if (session.activePrivateKey && session.profile.options.privateKeys && session.profile.options.privateKeys.length > 0) {
+                tmpFile = await tmp.file()
+                let passphrase: string|null = null
+                for (const pk of session.profile.options.privateKeys) {
+                    let privateKeyContent: string|null = null
+                    const buffer = await this.fileProviders.retrieveFile(pk)
+                    privateKeyContent = buffer.toString()
+                    await fs.writeFile(tmpFile.path, privateKeyContent)
+                    
+                    const keyHash = crypto.createHash('sha512').update(privateKeyContent).digest('hex')
+                    // need to pass an default passphrase with "tabby", otherwise it might get stuck at the passphrase input
+                    passphrase = await this.passwordStorage.loadPrivateKeyPassword(keyHash) ?? "tabby"
+    
+                    const winSCPcom = path.slice(0, -3) + 'com'
+                    try {
+                        await this.platform.exec(winSCPcom, ['/keygen', tmpFile.path, "-o", tmpFile.path, "--old-passphrase", passphrase])
+                    } catch (error) {
+                        console.warn("Could not convert private key ", error)
+                        continue
+                    }
+                    break
+                }
+                
+                args.push(`/privatekey=${tmpFile.path}`)
+                if (passphrase != null) {
+                    args.push(`/passphrase=${passphrase}`)
+                }
+            }
+            await this.platform.exec(path, args)
+        } finally {
+            tmpFile?.cleanup()
         }
-        await this.platform.exec(path, args)
-        tmpFile?.cleanup()
     }
 }


### PR DESCRIPTION
This PR attempts to fix #10113.

Read the location of the privateKey from `SSHSession.option.privateKeys` and pass the passphrase to `winscp.com /keygen`.

Tested scenarios:

* the privateKey from the file system or the vault.
* Read the saved password from passwordStorage.

Unsupported scenario:

* If the privateKey is set with a passphrase and the passphrase is not remembered, it will not prompt the user for the password and will throw an error at the /keygen step.

  To accomplish this, it may be necessary to modify or duplicate some code in `session/ssh.ts` `SSHSession.loadPrivateKeyWithPassphraseMaybe()`. Considering my implementation is a bit repetitive with some logic in `ssh.ts` , I haven't made modifications about this scenario.