### PR TITLE
Packagecloud upload for current Debian releases (bullseye, bookworm, trixie)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
         repo: 'eugeny/tabby'
         dir: 'dist'
         rpmvers: 'el/9 el/8 ol/6 ol/7'
-        debvers: 'ubuntu/bionic ubuntu/focal ubuntu/hirsute ubuntu/impish ubuntu/jammy ubuntu/kinetic ubuntu/noble ubuntu/oracular debian/jessie debian/stretch debian/buster'
+        debvers: 'ubuntu/bionic ubuntu/focal ubuntu/hirsute ubuntu/impish ubuntu/jammy ubuntu/kinetic ubuntu/noble ubuntu/oracular debian/jessie debian/stretch debian/buster debian/bullseye debian/bookworm debian/trixie'
 
     - uses: actions/upload-artifact@master
       name: Upload AppImage (${{matrix.arch}})


### PR DESCRIPTION
Currently, Debian deb packages are available only for releases up to buster (10). No package is available for newer releases.

This pull request adds uploads for bullseye, bookworm, and trixie (11–13), which correspond to oldstable, stable, and testing, respectively.