### PR TITLE
Add support for %h and %r escape characters in IdentityFile for SSH.

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -162,8 +162,10 @@ export class SSHSession {
         this.allAuthMethods = [{ type: 'none' }]
         if (!this.profile.options.auth || this.profile.options.auth === 'publicKey') {
             if (this.profile.options.privateKeys?.length) {
-                for (const pk of this.profile.options.privateKeys) {
+                for (let pk of this.profile.options.privateKeys) {
                     // eslint-disable-next-line @typescript-eslint/init-declarations
+                    pk = pk.replace("%h", this.profile.options.host)
+                    pk = pk.replace("%r", this.profile.options.user)
                     let contents: Buffer
                     try {
                         contents = await this.fileProviders.retrieveFile(pk)


### PR DESCRIPTION
See section "IdentityFile" on https://linux.die.net/man/5/ssh_config for details.

> IdentityFile
> Specifies a file from which the user's RSA or DSA authentication identity is read. The default is ~/.ssh/identity for protocol > version 1, and ~/.ssh/id_rsa and ~/.ssh/id_dsa for protocol version 2. Additionally, any identities represented by the > authentication agent will be used for authentication.

> The file name may use the tilde syntax to refer to a user's home directory or one of the following escape characters: '%d' > (local user's home directory), '%u' (local user name), '%l' (local host name), '%h' (remote host name) or '%r' (remote user > name).

> It is possible to have multiple identity files specified in configuration files; all these identities will be tried in sequence. 