### PR TITLE
fix(ssh/settings): formats date value according to locale rules

### DIFF
--- a/tabby-core/src/api/index.ts
+++ b/tabby-core/src/api/index.ts
@@ -36,7 +36,7 @@ export { TabsService, NewTabParameters, TabComponentType } from '../services/tab
 export { UpdaterService } from '../services/updater.service'
 export { VaultService, Vault, VaultSecret, VaultFileSecret, VAULT_SECRET_TYPE_FILE, StoredVault, VaultSecretKey } from '../services/vault.service'
 export { FileProvidersService } from '../services/fileProviders.service'
-export { LocaleService } from '../services/locale.service'
+export { LocaleService, TabbyFormatedDatePipe } from '../services/locale.service'
 export { TranslateService } from '@ngx-translate/core'
 export * from '../utils'
 export { UTF8Splitter } from '../utfSplitter'

--- a/tabby-core/src/index.ts
+++ b/tabby-core/src/index.ts
@@ -43,7 +43,7 @@ import { AppService } from './services/app.service'
 import { ConfigService } from './services/config.service'
 import { VaultFileProvider } from './services/vault.service'
 import { HotkeysService } from './services/hotkeys.service'
-import { CustomMissingTranslationHandler, LocaleService } from './services/locale.service'
+import { CustomMissingTranslationHandler, LocaleService, TabbyFormatedDatePipe } from './services/locale.service'
 import { CommandService } from './services/commands.service'
 
 import { NewTheme } from './theme'
@@ -130,6 +130,7 @@ const PROVIDERS = [
         DropZoneDirective,
         CdkAutoDropGroup,
         ProfileIconComponent,
+        TabbyFormatedDatePipe,
     ],
     exports: [
         AppRootComponent,
@@ -144,6 +145,7 @@ const PROVIDERS = [
         TranslateModule,
         CdkAutoDropGroup,
         ProfileIconComponent,
+        TabbyFormatedDatePipe,
     ],
 })
 export default class AppModule { // eslint-disable-line @typescript-eslint/no-extraneous-class

--- a/tabby-core/src/services/locale.service.ts
+++ b/tabby-core/src/services/locale.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core'
-import { registerLocaleData } from '@angular/common'
+import { Injectable, Pipe, PipeTransform } from '@angular/core'
+import { formatDate, registerLocaleData } from '@angular/common'
 import { TranslateService, MissingTranslationHandler } from '@ngx-translate/core'
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler'
 
@@ -255,5 +255,17 @@ export class LocaleService {
 
     getLocale (): string {
         return this.locale
+    }
+}
+
+@Pipe({
+    name: 'tabbyDate',
+})
+export class TabbyFormatedDatePipe implements PipeTransform {
+
+    constructor (private locale: LocaleService) {}
+
+    transform (date: string): string {
+        return formatDate(date, 'medium', this.locale.getLocale())
     }
 }

--- a/tabby-settings/src/components/configSyncSettingsTab.component.pug
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.pug
@@ -67,7 +67,7 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                                 div {{cfg.name}}
                                 small.text-muted(
                                     translate='Modified on {date}',
-                                    [translateParams]='{date: cfg.modified_at|date:"medium"}'
+                                    [translateParams]='{date: cfg.modified_at|date:"medium":undefined:getLocale()}'
                                 )
                             .me-auto
                             button.btn.btn-link.ms-1(

--- a/tabby-settings/src/components/configSyncSettingsTab.component.pug
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.pug
@@ -67,7 +67,7 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                                 div {{cfg.name}}
                                 small.text-muted(
                                     translate='Modified on {date}',
-                                    [translateParams]='{date: cfg.modified_at|date:"medium":undefined:getLocale()}'
+                                    [translateParams]='{date: cfg.modified_at|tabbyDate}'
                                 )
                             .me-auto
                             button.btn.btn-link.ms-1(

--- a/tabby-settings/src/components/configSyncSettingsTab.component.ts
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { Component, HostBinding } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseComponent, ConfigService, PromptModalComponent, HostAppService, PlatformService, NotificationsService, TranslateService } from 'tabby-core'
+import { BaseComponent, ConfigService, PromptModalComponent, HostAppService, PlatformService, NotificationsService, TranslateService, LocaleService } from 'tabby-core'
 import { Config, ConfigSyncService } from '../services/configSync.service'
 
 
@@ -25,6 +25,7 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
         private ngbModal: NgbModal,
         private notifications: NotificationsService,
         private translate: TranslateService,
+        private locale: LocaleService,
     ) {
         super()
     }
@@ -144,5 +145,9 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
 
     openTabbyWebInfo () {
         this.platform.openExternal('https://github.com/Eugeny/tabby-web')
+    }
+
+    getLocale (): string {
+        return this.locale.getLocale()
     }
 }

--- a/tabby-settings/src/components/configSyncSettingsTab.component.ts
+++ b/tabby-settings/src/components/configSyncSettingsTab.component.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { Component, HostBinding } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { BaseComponent, ConfigService, PromptModalComponent, HostAppService, PlatformService, NotificationsService, TranslateService, LocaleService } from 'tabby-core'
+import { BaseComponent, ConfigService, PromptModalComponent, HostAppService, PlatformService, NotificationsService, TranslateService } from 'tabby-core'
 import { Config, ConfigSyncService } from '../services/configSync.service'
 
 
@@ -25,7 +25,6 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
         private ngbModal: NgbModal,
         private notifications: NotificationsService,
         private translate: TranslateService,
-        private locale: LocaleService,
     ) {
         super()
     }
@@ -147,7 +146,4 @@ export class ConfigSyncSettingsTabComponent extends BaseComponent {
         this.platform.openExternal('https://github.com/Eugeny/tabby-web')
     }
 
-    getLocale (): string {
-        return this.locale.getLocale()
-    }
 }

--- a/tabby-settings/src/components/releaseNotesTab.component.pug
+++ b/tabby-settings/src/components/releaseNotesTab.component.pug
@@ -8,5 +8,5 @@
 )
     div(*ngFor='let release of releases')
         h1 {{release.name}}
-        .text-muted {{release.version}} / {{release.date|date:'mediumDate'}}
+        .text-muted {{release.version}} / {{release.date|date:'mediumDate':undefined:getLocale()}}
         section([fastHtmlBind]='release.content')

--- a/tabby-settings/src/components/releaseNotesTab.component.pug
+++ b/tabby-settings/src/components/releaseNotesTab.component.pug
@@ -8,5 +8,5 @@
 )
     div(*ngFor='let release of releases')
         h1 {{release.name}}
-        .text-muted {{release.version}} / {{release.date|date:'mediumDate':undefined:getLocale()}}
+        .text-muted {{release.version}} / {{release.date|tabbyDate}}
         section([fastHtmlBind]='release.content')

--- a/tabby-settings/src/components/releaseNotesTab.component.ts
+++ b/tabby-settings/src/components/releaseNotesTab.component.ts
@@ -3,7 +3,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import axios from 'axios'
 import * as marked from '../../node_modules/marked/src/marked'
 import { Component, Injector } from '@angular/core'
-import { BaseTabComponent, TranslateService } from 'tabby-core'
+import { BaseTabComponent, TranslateService, LocaleService } from 'tabby-core'
 
 export interface Release {
     name: string
@@ -22,7 +22,7 @@ export class ReleaseNotesComponent extends BaseTabComponent {
     releases: Release[] = []
     lastPage = 1
 
-    constructor (translate: TranslateService, injector: Injector) {
+    constructor (translate: TranslateService, private locale: LocaleService, injector: Injector) {
         super(injector)
         this.setTitle(translate.instant(_('Release notes')))
         this.loadReleases(1)
@@ -44,5 +44,9 @@ export class ReleaseNotesComponent extends BaseTabComponent {
 
     onScrolled () {
         this.loadReleases(this.lastPage + 1)
+    }
+
+    getLocale (): string {
+        return this.locale.getLocale()
     }
 }

--- a/tabby-settings/src/components/releaseNotesTab.component.ts
+++ b/tabby-settings/src/components/releaseNotesTab.component.ts
@@ -3,7 +3,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import axios from 'axios'
 import * as marked from '../../node_modules/marked/src/marked'
 import { Component, Injector } from '@angular/core'
-import { BaseTabComponent, TranslateService, LocaleService } from 'tabby-core'
+import { BaseTabComponent, TranslateService } from 'tabby-core'
 
 export interface Release {
     name: string
@@ -22,7 +22,7 @@ export class ReleaseNotesComponent extends BaseTabComponent {
     releases: Release[] = []
     lastPage = 1
 
-    constructor (translate: TranslateService, private locale: LocaleService, injector: Injector) {
+    constructor (translate: TranslateService, injector: Injector) {
         super(injector)
         this.setTitle(translate.instant(_('Release notes')))
         this.loadReleases(1)
@@ -46,7 +46,4 @@ export class ReleaseNotesComponent extends BaseTabComponent {
         this.loadReleases(this.lastPage + 1)
     }
 
-    getLocale (): string {
-        return this.locale.getLocale()
-    }
 }

--- a/tabby-ssh/src/components/sftpPanel.component.pug
+++ b/tabby-ssh/src/components/sftpPanel.component.pug
@@ -61,5 +61,5 @@
                 div {{item.name}}
                 .me-auto
                 .size(*ngIf='!item.isDirectory') {{item.size|filesize}}
-                .date {{item.modified|date:'medium'}}
+                .date {{item.modified|date:'medium':undefined:getLocale()}}
                 .mode {{getModeString(item)}}

--- a/tabby-ssh/src/components/sftpPanel.component.pug
+++ b/tabby-ssh/src/components/sftpPanel.component.pug
@@ -61,5 +61,5 @@
                 div {{item.name}}
                 .me-auto
                 .size(*ngIf='!item.isDirectory') {{item.size|filesize}}
-                .date {{item.modified|date:'medium':undefined:getLocale()}}
+                .date {{item.modified|tabbyDate}}
                 .mode {{getModeString(item)}}

--- a/tabby-ssh/src/components/sftpPanel.component.ts
+++ b/tabby-ssh/src/components/sftpPanel.component.ts
@@ -1,7 +1,7 @@
 import * as C from 'constants'
 import { posix as path } from 'path'
 import { Component, Input, Output, EventEmitter, Inject, Optional } from '@angular/core'
-import { FileUpload, DirectoryUpload, MenuItemOptions, NotificationsService, PlatformService, LocaleService } from 'tabby-core'
+import { FileUpload, DirectoryUpload, MenuItemOptions, NotificationsService, PlatformService } from 'tabby-core'
 import { SFTPSession, SFTPFile } from '../session/sftp'
 import { SSHSession } from '../session/ssh'
 import { SFTPContextMenuItemProvider } from '../api'
@@ -32,7 +32,6 @@ export class SFTPPanelComponent {
     constructor (
         private ngbModal: NgbModal,
         private notifications: NotificationsService,
-        private locale: LocaleService,
         public platform: PlatformService,
         @Optional() @Inject(SFTPContextMenuItemProvider) protected contextMenuProviders: SFTPContextMenuItemProvider[],
     ) {
@@ -275,7 +274,4 @@ export class SFTPPanelComponent {
         this.closed.emit()
     }
 
-    getLocale (): string {
-        return this.locale.getLocale()
-    }
 }

--- a/tabby-ssh/src/components/sftpPanel.component.ts
+++ b/tabby-ssh/src/components/sftpPanel.component.ts
@@ -1,7 +1,7 @@
 import * as C from 'constants'
 import { posix as path } from 'path'
 import { Component, Input, Output, EventEmitter, Inject, Optional } from '@angular/core'
-import { FileUpload, DirectoryUpload, MenuItemOptions, NotificationsService, PlatformService } from 'tabby-core'
+import { FileUpload, DirectoryUpload, MenuItemOptions, NotificationsService, PlatformService, LocaleService } from 'tabby-core'
 import { SFTPSession, SFTPFile } from '../session/sftp'
 import { SSHSession } from '../session/ssh'
 import { SFTPContextMenuItemProvider } from '../api'
@@ -32,6 +32,7 @@ export class SFTPPanelComponent {
     constructor (
         private ngbModal: NgbModal,
         private notifications: NotificationsService,
+        private locale: LocaleService,
         public platform: PlatformService,
         @Optional() @Inject(SFTPContextMenuItemProvider) protected contextMenuProviders: SFTPContextMenuItemProvider[],
     ) {
@@ -272,5 +273,9 @@ export class SFTPPanelComponent {
 
     close (): void {
         this.closed.emit()
+    }
+
+    getLocale (): string {
+        return this.locale.getLocale()
     }
 }


### PR DESCRIPTION
Hey Eugene, 

Asked in Clem-Fern/rtabby-web-api#29, Formats date value according to locale rules.
I've only found 3 places in which date are displayed (release notes, FTP, config sync).

EN
![image](https://github.com/user-attachments/assets/e6eb2f63-78c9-4e81-b7fb-3400b033a627)

FR now
![image](https://github.com/user-attachments/assets/f8c926a2-79a4-446b-a5ee-e5589e00a277)

FR before
![image](https://github.com/user-attachments/assets/7f16dee1-c252-43fd-997e-219318feaf3f)

