### PR TITLE
SSH password paste

### DIFF
--- a/tabby-ssh/src/config.ts
+++ b/tabby-ssh/src/config.ts
@@ -15,6 +15,7 @@ export class SSHConfigProvider extends ConfigProvider {
         hotkeys: {
             'restart-ssh-session': [],
             'launch-winscp': [],
+            'paste-ssh-password': ['Ctrl+K'],
         },
     }
 

--- a/tabby-ssh/src/hotkeys.ts
+++ b/tabby-ssh/src/hotkeys.ts
@@ -13,6 +13,10 @@ export class SSHHotkeyProvider extends HotkeyProvider {
             id: 'launch-winscp',
             name: this.translate.instant('Launch WinSCP for current SSH session'),
         },
+        {
+            id: 'paste-ssh-password',
+            name: this.translate.instant('Paste active profile password'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }


### PR DESCRIPTION
This feature allows users to paste passwords in the terminal of active SSH session, useful when host asks frequently for password.
Ctrl+K is the default keystroke.