### PR TITLE
[Feature] Group subgroups

### DIFF
--- a/tabby-core/src/api/profileProvider.ts
+++ b/tabby-core/src/api/profileProvider.ts
@@ -37,6 +37,9 @@ export type PartialProfile<T extends Profile> = Omit<Omit<Omit<{
 
 export interface ProfileGroup {
     id: string
+    parentGroupId?: string
+    icon?: string
+    color?: string
     name: string
     profiles: PartialProfile<Profile>[]
     defaults: any

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -221,7 +221,30 @@ export class ProfilesService {
         }
     }
 
-    showProfileSelector (): Promise<PartialProfile<Profile>|null> {
+    buildGroupTree (groups: PartialProfileGroup<ProfileGroup & { [key: string]: any }>[]): PartialProfileGroup<ProfileGroup & { [key: string]: any }>[] {
+        const map = new Map<string, PartialProfileGroup<ProfileGroup & { [key: string]: any }>>()
+
+        for (const group of groups) {
+            group.children = []
+            map.set(group.id, group)
+        }
+
+        const roots: PartialProfileGroup<ProfileGroup & { [key: string]: any }>[] = []
+
+        for (const group of groups) {
+            if (group.parentGroupId) {
+                const parent = map.get(group.parentGroupId)
+                if (parent) parent.children!.push(group)
+                else roots.push(group) // Orphaned group, treat as root
+            } else {
+                roots.push(group)
+            }
+        }
+
+        return roots
+    }
+
+    showProfileSelector (): Promise<PartialProfile<Profile> | null> {
         if (this.selector.active) {
             return Promise.resolve(null)
         }

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -284,6 +284,7 @@ export class ProfilesService {
 
                 if (!this.config.store.terminal.showBuiltinProfiles) {
                     profiles = profiles.filter(x => !x.isBuiltin)
+                } else {
                     profiles = profiles.map(p => {
                         if (p.isBuiltin) p.group = "Built-in"
                         if (!p.icon) p.icon = 'fas fa-network-wired'
@@ -527,7 +528,6 @@ export class ProfilesService {
     * Resolve and return ProfileGroup Name from ProfileGroup ID
     */
     resolveProfileGroupName (groupId: string): string {
-        return this.config.store.groups.find(g => g.id === groupId)?.name ?? groupId
         const group = this.resolveProfileGroup(groupId);
         return group?.name ?? groupId
     }

--- a/tabby-settings/src/components/editProfileGroupModal.component.pug
+++ b/tabby-settings/src/components/editProfileGroupModal.component.pug
@@ -12,7 +12,56 @@
                     [(ngModel)]='group.name',
                 )
 
-        .col-12.col-lg-8
+            .mb-3
+                label(translate) Parent Group
+                input.form-control(
+                    type='text',
+                    alwaysVisibleTypeahead,
+                    placeholder='Ungrouped',
+                    [(ngModel)]='selectedParentGroup',
+                    [ngbTypeahead]='groupTypeahead',
+                    [inputFormatter]="groupFormatter",
+			        [resultFormatter]="groupFormatter",
+			        [editable]="false"
+                )
+
+            .mb-3
+                label(translate) Icon
+                .input-group
+                    input.form-control(
+                        type='text',
+                        alwaysVisibleTypeahead,
+                        [(ngModel)]='group.icon',
+                        [ngbTypeahead]='iconSearch',
+                        [resultTemplate]='rt'
+                    )
+                    .input-group-text
+                        profile-icon(
+                            [icon]='group.icon',
+                            [color]='group.color'
+                        )
+
+                ng-template(#rt,let-r='result',let-t='term')
+                    i([class]='"fa-fw " + r')
+                    ngb-highlight.ms-2([result]='r', [term]='t')
+
+            .mb-3
+                label(translate) Color
+                .input-group
+                    input.form-control.color-picker(
+                        type='color',
+                        [(ngModel)]='group.color',
+                        [ngbTypeahead]='colorsAutocomplete',
+                        [resultFormatter]='colorsFormatter'
+                    )
+                    input.form-control(
+                        type='text',
+                        [(ngModel)]='group.color',
+                        [ngbTypeahead]='colorsAutocomplete',
+                        [resultFormatter]='colorsFormatter'
+                    )
+
+        .col-12.col-lg-8(*ngIf='providers.length !== 0')
             .form-line.content-box
                 .header
                     .title(translate) Default profile group settings

--- a/tabby-settings/src/components/editProfileGroupModal.component.ts
+++ b/tabby-settings/src/components/editProfileGroupModal.component.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { Component, Input } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigProxy, ProfileGroup, Profile, ProfileProvider, PlatformService, TranslateService } from 'tabby-core'
+import { Observable, OperatorFunction, debounceTime, map, distinctUntilChanged } from 'rxjs'
+import { ConfigProxy, ProfileGroup, Profile, ProfileProvider, PlatformService, TranslateService, PartialProfileGroup, ProfilesService, TAB_COLORS } from 'tabby-core'
+
+const iconsData = require('../../../tabby-core/src/icons.json')
+const iconsClassList = Object.keys(iconsData).map(
+    icon => iconsData[icon].map(
+        style => `fa${style[0]} fa-${icon}`,
+    ),
+).flat()
 
 /** @hidden */
 @Component({
@@ -10,14 +18,105 @@ import { ConfigProxy, ProfileGroup, Profile, ProfileProvider, PlatformService, T
 export class EditProfileGroupModalComponent<G extends ProfileGroup> {
     @Input() group: G & ConfigProxy
     @Input() providers: ProfileProvider<Profile>[]
+    @Input() selectedParentGroup: PartialProfileGroup<ProfileGroup> | undefined
+    groups: PartialProfileGroup<ProfileGroup>[]
 
-    constructor (
+    getValidParents (groups: PartialProfileGroup<ProfileGroup>[], targetId: string): PartialProfileGroup<ProfileGroup>[] {
+        // Build a quick lookup: parentGroupId -> [child groups]
+        const childrenMap = new Map<string | null, string[]>();
+        for (const group of groups) {
+            const parent = group.parentGroupId ?? null;
+            if (!childrenMap.has(parent)) {
+                childrenMap.set(parent, []);
+            }
+            childrenMap.get(parent)!.push(group.id);
+        }
+
+        // Depth-first search to find all descendants of target
+        function getDescendants (id: string): Set<string> {
+            const descendants = new Set<string>();
+            const stack: string[] = [id];
+
+            while (stack.length > 0) {
+                const current = stack.pop()!;
+                const children = childrenMap.get(current);
+                if (children) {
+                    for (const child of children) {
+                        if (!descendants.has(child)) {
+                            descendants.add(child);
+                            stack.push(child);
+                        }
+                    }
+                }
+            }
+            return descendants;
+        }
+
+        const descendants = getDescendants(targetId);
+
+        // Valid parents = all groups that are not the target or its descendants
+        return groups.filter(
+            (g) => g.id !== targetId && !descendants.has(g.id)
+        );
+    }
+
+    constructor(
         private modalInstance: NgbActiveModal,
+        private profilesService: ProfilesService,
         private platform: PlatformService,
         private translate: TranslateService,
-    ) {}
+    ) {
+        this.profilesService.getProfileGroups().then(groups => {
+            this.groups = this.getValidParents(groups, this.group?.id)
+            this.selectedParentGroup = groups.find(g => g.id === this.group.parentGroupId) ?? undefined
+        })
+    }
 
-    save () {
+    colorsAutocomplete = text$ => text$.pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        map((q: string) =>
+            TAB_COLORS
+                .filter(x => !q || x.name.toLowerCase().startsWith(q.toLowerCase()))
+                .map(x => x.value),
+        ),
+    )
+
+    colorsFormatter = value => {
+        return TAB_COLORS.find(x => x.value === value)?.name ?? value
+    }
+
+    groupTypeahead: OperatorFunction<string, readonly PartialProfileGroup<ProfileGroup>[]> = (text$: Observable<string>) =>
+        text$.pipe(
+            debounceTime(200),
+            distinctUntilChanged(),
+            map(q => this.groups.filter(g => !q || g.name.toLowerCase().includes(q.toLowerCase()))),
+        )
+
+    groupFormatter = (g: PartialProfileGroup<ProfileGroup>) => g.name
+
+    iconSearch: OperatorFunction<string, string[]> = (text$: Observable<string>) =>
+        text$.pipe(
+            debounceTime(200),
+            map(term => iconsClassList.filter(v => v.toLowerCase().includes(term.toLowerCase())).slice(0, 10)),
+        )
+
+    async save () {
+        if (!this.selectedParentGroup) {
+            this.group.parentGroupId = undefined
+        } else {
+            this.group.parentGroupId = this.selectedParentGroup.id
+        }
+
+        if (this.group.id === 'new') {
+            await this.profilesService.newProfileGroup({
+                id: '',
+                name: this.group.name,
+                icon: this.group?.icon,
+                color: this.group?.color,
+                parentGroupId: this.group?.parentGroupId
+            })
+        }
         this.modalInstance.close({ group: this.group })
     }
 

--- a/tabby-settings/src/components/editProfileGroupModal.component.ts
+++ b/tabby-settings/src/components/editProfileGroupModal.component.ts
@@ -60,7 +60,7 @@ export class EditProfileGroupModalComponent<G extends ProfileGroup> {
         );
     }
 
-    constructor(
+    constructor (
         private modalInstance: NgbActiveModal,
         private profilesService: ProfilesService,
         private platform: PlatformService,
@@ -109,13 +109,7 @@ export class EditProfileGroupModalComponent<G extends ProfileGroup> {
         }
 
         if (this.group.id === 'new') {
-            await this.profilesService.newProfileGroup({
-                id: '',
-                name: this.group.name,
-                icon: this.group?.icon,
-                color: this.group?.color,
-                parentGroupId: this.group?.parentGroupId
-            })
+            await this.profilesService.newProfileGroup(this.group, { genId: true })
         }
         this.modalInstance.close({ group: this.group })
     }

--- a/tabby-settings/src/components/profilesSettingsTab.component.pug
+++ b/tabby-settings/src/components/profilesSettingsTab.component.pug
@@ -39,87 +39,39 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                             span(translate) New profile
                         button(ngbDropdownItem, (click)='newProfileGroup()')
                             i.fas.fa-fw.fa-plus
-                            span(translate) New profile Group
+                            span(translate) New profile Group            
+            
+            .d-flex.flex-column.my-3.p-2.collapse-container
+                ng-container(*ngFor='let group of rootGroups')
+                    ng-container(*ngTemplateOutlet='recursiveGroup; context: {$implicit: group}')
 
-            .list-group.mt-3.mb-3
-                ng-container(*ngFor='let group of profileGroups')
-                    ng-container(*ngIf='isGroupVisible(group)')
-                        .list-group-item.list-group-item-action.d-flex.align-items-center(
-                            (click)='toggleGroupCollapse(group)'
-                        )
-                            .fa.fa-fw.fa-chevron-right(*ngIf='group.collapsed && group.profiles?.length > 0')
-                            .fa.fa-fw.fa-chevron-down(*ngIf='!group.collapsed && group.profiles?.length > 0')
-                            span.ms-3.me-auto {{group.name || ("Ungrouped"|translate)}}
-                            button.btn.btn-sm.btn-link.hover-reveal.ms-2(
-                                *ngIf='group.editable && group.name',
-                                (click)='$event.stopPropagation(); editProfileGroup(group)'
-                            )
-                                i.fas.fa-pencil-alt
-                            button.btn.btn-sm.btn-link.hover-reveal.ms-2(
-                                *ngIf='group.editable && group.name',
-                                (click)='$event.stopPropagation(); deleteProfileGroup(group)'
-                            )
-                                i.fas.fa-trash-alt
-                        ng-container(*ngIf='!group.collapsed')
-                            ng-container(*ngFor='let profile of group.profiles')
-                                .list-group-item.ps-5.d-flex.align-items-center(
-                                    *ngIf='isProfileVisible(profile)',
-                                    [class.list-group-item-action]='!profile.isBuiltin',
-                                    (click)='profile.isBuiltin ? null : editProfile(profile)'
-                                )
-                                    profile-icon(
-                                        [icon]='profile.icon',
-                                        [color]='profile.color'
-                                    )
+            ng-template(#recursiveGroup let-group)
+                .collapse-item.d-flex.align-items-center.p-1((click)='toggleGroupCollapse(group)')
+                    .fa.fa-fw.far.fa-folder.ms-1(*ngIf='group.collapsed')
+                    .fa.fa-fw.far.fa-folder-open.ms-1(*ngIf='!group.collapsed')
+                    //- profile-icon.ms-1([icon]='group.icon', [color]='group.color')
+                    span.ms-3.me-auto {{ group.name || ("Ungrouped"|translate) }}
 
-                                    .no-wrap {{profile.name}}
-                                    .text-muted.no-wrap.ms-2 {{getDescription(profile)}}
+                    button.btn.btn-sm.btn-link.hover-reveal.ms-2(*ngIf='group.editable && group.name', (click)='$event.stopPropagation(); editProfileGroup(group)')
+                        i.fas.fa-pencil-alt
+                    button.btn.btn-sm.btn-link.hover-reveal.ms-2(*ngIf='group.editable && group.name', (click)='$event.stopPropagation(); deleteProfileGroup(group)')
+                        i.fas.fa-trash-alt
+                
+                ng-container(*ngIf='!group.collapsed')
+                    ng-container(*ngFor='let profile of group.profiles')
+                        .collapse-item.d-flex.align-items-center.p-1.ps-4(*ngIf='isProfileVisible(profile)', [class.list-group-item-action]='!profile.isBuiltin', (click)='profile.isBuiltin ? null : editProfile(profile)')
+                            profile-icon.ms-1([icon]='profile.icon', [color]='profile.color')
+                            span.ms-3.no-wrap {{ profile.name }}
+                            .text-muted.no-wrap.ms-2 {{ getDescription(profile) }}
+                            .me-auto
+                            button.btn.btn-link.hover-reveal.ms-1(*ngIf='!profile.isTemplate', (click)='$event.stopPropagation(); launchProfile(profile)')
+                                i.fas.fa-play
+                            
+                            .mx-2(class='badge text-bg-{{getTypeColorClass(profile)}}') {{ getTypeLabel(profile) }}
 
-                                    .me-auto
-
-                                    button.btn.btn-link.hover-reveal.ms-1(*ngIf='!profile.isTemplate', (click)='$event.stopPropagation(); launchProfile(profile)')
-                                        i.fas.fa-play
-
-                                    .ms-1.hover-reveal(ngbDropdown, placement='bottom-right top-right auto')
-                                        button.btn.btn-link.ms-1(
-                                            ngbDropdownToggle,
-                                            (click)='$event.stopPropagation()'
-                                        )
-                                            i.fas.fa-fw.fa-ellipsis-vertical
-                                        div(ngbDropdownMenu)
-                                            button.dropdown-item(
-                                                ngbDropdownItem,
-                                                (click)='$event.stopPropagation(); newProfile(profile)'
-                                            )
-                                                i.fas.fa-fw.fa-copy
-                                                span(translate) Duplicate
-
-                                            button.dropdown-item(
-                                                ngbDropdownItem,
-                                                *ngIf='profile.id && !isProfileBlacklisted(profile)',
-                                                (click)='$event.stopPropagation(); blacklistProfile(profile)'
-                                            )
-                                                i.fas.fa-fw.fa-eye-slash
-                                                span(translate) Hide
-
-                                            button.dropdown-item(
-                                                ngbDropdownItem,
-                                                *ngIf='profile.id && isProfileBlacklisted(profile)',
-                                                (click)='$event.stopPropagation(); unblacklistProfile(profile)'
-                                            )
-                                                i.fas.fa-fw.fa-eye
-                                                span(translate) Show
-
-                                            button.dropdown-item(
-                                                *ngIf='!profile.isBuiltin',
-                                                (click)='$event.stopPropagation(); deleteProfile(profile)'
-                                            )
-                                                i.fas.fa-fw.fa-trash-alt
-                                                span(translate) Delete
-
-                                    .ms-1(class='badge text-bg-{{getTypeColorClass(profile)}}') {{getTypeLabel(profile)}}
-
-                                    .ms-1.text-danger.fas.fa-eye-slash(*ngIf='isProfileBlacklisted(profile)')
+                    ng-container(*ngFor='let child of group.children')
+                        .ps-4
+                            ng-container(*ngTemplateOutlet='recursiveGroup; context: {$implicit: child}')
 
     li(ngbNavItem)
         a(ngbNavLink, translate) Advanced

--- a/tabby-settings/src/components/profilesSettingsTab.component.scss
+++ b/tabby-settings/src/components/profilesSettingsTab.component.scss
@@ -1,8 +1,20 @@
 profile-icon {
-    width: 1.25rem;
-    margin-right: 0.25rem;
+    width: 1rem;
+    height: 1rem;
 }
 
-profile-icon + * {
-    margin-left: 10px;
+.collapse-container {
+    background-color: var(--theme-bg-less);
+    border-radius: 0.375rem;
+}
+
+.collapse-item {
+    height: 2.25rem;
+    background-color: var(--theme-bg-less);
+    border-radius: 0.3rem;
+    cursor: pointer;
+}
+
+.collapse-item:hover {
+    background-color: var(--theme-bg-less-2);
 }

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -173,20 +173,11 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     }
 
     async newProfileGroup (): Promise<void> {
-        const modal = this.ngbModal.open(
-            EditProfileGroupModalComponent,
-            { size: 'lg' },
-        )
-        modal.componentInstance.group = {
+        this.editProfileGroup({
             id: 'new',
-            icon: 'far fa-folder',
-            color: '#B8B8B8'
-        }
-        modal.componentInstance.providers = []
-
-        const createResult: EditProfileGroupModalComponentResult<CollapsableProfileGroup> | null = await modal.result.catch(() => null)
-        if (!createResult) return
-        await this.config.save()
+            name: '',
+            icon: 'far fa-folder'
+        })
     }
 
     async editProfileGroup (group: PartialProfileGroup<CollapsableProfileGroup>): Promise<void> {
@@ -194,9 +185,6 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         if (!result) {
             return
         }
-
-        // don't save children to the config
-        delete group.children;
 
         await this.profilesService.writeProfileGroup(ProfilesSettingsTabComponent.collapsableIntoPartialProfileGroup(result))
         await this.config.save()
@@ -399,6 +387,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     private static collapsableIntoPartialProfileGroup (group: PartialProfileGroup<CollapsableProfileGroup>): PartialProfileGroup<ProfileGroup> {
         const g: any = { ...group }
         delete g.collapsed
+        delete g.children
         return g
     }
 

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -62,29 +62,6 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         this.profilesService.openNewTabForProfile(profile)
     }
 
-    private buildGroupTree (groups: PartialProfileGroup<CollapsableProfileGroup>[]): PartialProfileGroup<CollapsableProfileGroup>[] {
-        const map = new Map<string, PartialProfileGroup<CollapsableProfileGroup>>()
-
-        for (const group of groups) {
-            group.children = []
-            map.set(group.id, group)
-        }
-
-        const roots: PartialProfileGroup<CollapsableProfileGroup>[] = []
-
-        for (const group of groups) {
-            if (group.parentGroupId) {
-                const parent = map.get(group.parentGroupId)
-                if (parent) parent.children!.push(group)
-                else roots.push(group) // Orphaned group, treat as root
-            } else {
-                roots.push(group)
-            }
-        }
-
-        return roots
-    }
-
     async newProfile (base?: PartialProfile<Profile>): Promise<void> {
         if (!base) {
             let profiles = await this.profilesService.getProfiles()
@@ -279,7 +256,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         groups.sort((a, b) => (a.id === 'built-in' || !a.editable ? 1 : 0) - (b.id === 'built-in' || !b.editable ? 1 : 0))
         groups.sort((a, b) => (a.id === 'ungrouped' ? 0 : 1) - (b.id === 'ungrouped' ? 0 : 1))
         this.profileGroups = groups.map(g => ProfilesSettingsTabComponent.intoPartialCollapsableProfileGroup(g, profileGroupCollapsed[g.id] ?? false))
-        this.rootGroups = this.buildGroupTree(this.profileGroups)
+        this.rootGroups = this.profilesService.buildGroupTree(this.profileGroups)
     }
 
     isGroupVisible (group: PartialProfileGroup<ProfileGroup>): boolean {

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -2,7 +2,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import deepClone from 'clone-deep'
 import { Component, Inject } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigService, HostAppService, Profile, SelectorService, ProfilesService, PromptModalComponent, PlatformService, BaseComponent, PartialProfile, ProfileProvider, TranslateService, Platform, ProfileGroup, PartialProfileGroup, QuickConnectProfileProvider } from 'tabby-core'
+import { ConfigService, HostAppService, Profile, SelectorService, ProfilesService, PlatformService, BaseComponent, PartialProfile, ProfileProvider, TranslateService, Platform, ProfileGroup, PartialProfileGroup, QuickConnectProfileProvider } from 'tabby-core'
 import { EditProfileModalComponent } from './editProfileModal.component'
 import { EditProfileGroupModalComponent, EditProfileGroupModalComponentResult } from './editProfileGroupModal.component'
 


### PR DESCRIPTION
This pull request adds the ability to nest groups underneath each other, in addition to adding icons and colors to groups.
This lays the groundwork for a future pull request that adds a profile tree panel.

<img width="939" height="960" alt="image" src="https://github.com/user-attachments/assets/262fbc6f-dab2-489a-a39d-491466719d15" />

Care has been taken to ensure backwards compatibility with previous configs.
`parentGroupId`, `icon`, `color` fields have been added to the `groups` configuration items
```
groups:
  - id: 62c453d2-01d0-47e1-8723-1eec6373323e
    name: Group 1
    icon: fas fa-layer-group
    color: '#e294ff'
  - id: 7398c52c-2381-4f42-a8b3-816d8b5930e4
    name: Group 2
    icon: fas fa-4
    color: '#ffe33e'
  - id: f667f830-03af-48c9-b1b8-cfee8bfa84ac
    name: Group 3
    icon: fas fa-boxes-stacked
    color: '#4800f0'
```

The search modal has also been changed to reflect the full group path as opposed to only the profile's parent group name.
<img width="539" height="725" alt="image" src="https://github.com/user-attachments/assets/49261203-a6a1-41db-af3c-e6e208bfad9a" />


Linked issues #9758 #9210 #411