### PR TITLE
fix: preserve scroll position on tab switch and visibility change

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -447,7 +447,13 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             .subscribe(visibility => {
                 if (this.frontend instanceof XTermFrontend) {
                     if (visibility) {
+                        const xtermCore = (this.frontend.xterm as any)._core
+                        const savedYdisp = xtermCore.buffer.ydisp
                         this.frontend.xterm.refresh(0, this.frontend.xterm.rows - 1)
+                        if (xtermCore.buffer.ydisp !== savedYdisp) {
+                            xtermCore.buffer.ydisp = savedYdisp
+                            this.frontend.xterm.refresh(0, this.frontend.xterm.rows - 1)
+                        }
                     } else {
                         this.frontend.xterm.element?.querySelectorAll('canvas').forEach(c => {
                             c.height = c.width = 0

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -447,12 +447,10 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             .subscribe(visibility => {
                 if (this.frontend instanceof XTermFrontend) {
                     if (visibility) {
-                        const xtermCore = (this.frontend.xterm as any)._core
-                        const savedYdisp = xtermCore.buffer.ydisp
+                        const savedViewportY = this.frontend.xterm.buffer.active.viewportY
                         this.frontend.xterm.refresh(0, this.frontend.xterm.rows - 1)
-                        if (xtermCore.buffer.ydisp !== savedYdisp) {
-                            xtermCore.buffer.ydisp = savedYdisp
-                            this.frontend.xterm.refresh(0, this.frontend.xterm.rows - 1)
+                        if (this.frontend.xterm.buffer.active.viewportY !== savedViewportY) {
+                            this.frontend.xterm.scrollToLine(savedViewportY)
                         }
                     } else {
                         this.frontend.xterm.element?.querySelectorAll('canvas').forEach(c => {

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -218,8 +218,13 @@ export class XTermFrontend extends Frontend {
         this.resizeHandler = () => {
             try {
                 if (this.xterm.element && getComputedStyle(this.xterm.element).getPropertyValue('height') !== 'auto') {
+                    const savedYdisp = this.xtermCore.buffer.ydisp
                     this.fitAddon.fit()
                     this.xterm.refresh(0, this.xterm.rows - 1)
+                    if (this.xtermCore.buffer.ydisp !== savedYdisp) {
+                        this.xtermCore.buffer.ydisp = savedYdisp
+                        this.xterm.refresh(0, this.xterm.rows - 1)
+                    }
                 }
             } catch (e) {
                 // tends to throw when element wasn't shown yet

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -218,12 +218,13 @@ export class XTermFrontend extends Frontend {
         this.resizeHandler = () => {
             try {
                 if (this.xterm.element && getComputedStyle(this.xterm.element).getPropertyValue('height') !== 'auto') {
-                    const savedYdisp = this.xtermCore.buffer.ydisp
+                    const savedViewportY = this.xterm.buffer.active.viewportY
                     this.fitAddon.fit()
                     this.xterm.refresh(0, this.xterm.rows - 1)
-                    if (this.xtermCore.buffer.ydisp !== savedYdisp) {
-                        this.xtermCore.buffer.ydisp = savedYdisp
-                        this.xterm.refresh(0, this.xterm.rows - 1)
+                    const maxYdisp = this.xterm.buffer.active.baseY
+                    const restoredYdisp = Math.max(0, Math.min(savedViewportY, maxYdisp))
+                    if (this.xterm.buffer.active.viewportY !== restoredYdisp) {
+                        this.xterm.scrollToLine(restoredYdisp)
                     }
                 }
             } catch (e) {


### PR DESCRIPTION
## Summary

- Saves `buffer.ydisp` (scroll offset) before `fitAddon.fit()` / `xterm.refresh()` and restores it if it was unexpectedly changed
- Patches both the `resizeHandler` in `xtermFrontend.ts` and the visibility change subscriber in `baseTerminalTab.component.ts`

## Problem

When switching tabs, toggling window focus, or clicking away from Tabby, the terminal viewport jumps to the middle or top of the scrollback buffer. This happens because:

1. Tab switch triggers `emitVisibility(true)` + `emitFocused()` on the active tab
2. `emitFocused()` calls `configure()` which calls `resizeHandler()`
3. `resizeHandler()` calls `fitAddon.fit()` then `xterm.refresh()`, which can reset `buffer.ydisp`
4. `scrollToBottom()` is overridden to be a no-op (line 216), so nothing corrects the position

This is especially disruptive for long-running sessions (e.g. Claude Code, log tailing) where maintaining scroll position matters.

## Fix

Before each resize/refresh operation, snapshot `buffer.ydisp`. After the operation, if `ydisp` changed, restore it and re-refresh. The conditional check avoids a redundant refresh when the scroll position wasn't affected.

## Fixes

- #10127 - Tab scrolls to bottom on focus change (Windows 11)
- #10102 - Scroll position resets on window switch
- #10648 - Claude Code scrolling issues
- #11111 - Terminal window always scrolls to top automatically

## Test plan

- [x] TypeScript compiles with zero errors (`tsc --noEmit`)
- [x] Patched compiled dist on installed Tabby 1.0.197-nightly and verified fix works
- [ ] Open multiple terminal tabs with scrollback history
- [ ] Switch between tabs rapidly - scroll position should not change
- [ ] Alt-tab away from Tabby and back - scroll position should not change
- [ ] Verify actual window resize still adjusts scroll as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)