### PR TITLE
fix: remove Ctrl+Space as default toggle-window global hotkey

### DIFF
--- a/tabby-electron/src/config.ts
+++ b/tabby-electron/src/config.ts
@@ -5,19 +5,16 @@ export class ElectronConfigProvider extends ConfigProvider {
     platformDefaults = {
         [Platform.macOS]: {
             hotkeys: {
-                'toggle-window': ['Ctrl-Space'],
                 'new-window': ['⌘-N'],
             },
         },
         [Platform.Windows]: {
             hotkeys: {
-                'toggle-window': ['Ctrl-Space'],
                 'new-window': ['Ctrl-Shift-N'],
             },
         },
         [Platform.Linux]: {
             hotkeys: {
-                'toggle-window': ['Ctrl-Space'],
                 'new-window': ['Ctrl-Shift-N'],
             },
         },


### PR DESCRIPTION
## Problem

\`Ctrl+Space\` is currently the default global hotkey for \`toggle-window\` on all platforms. Because it is registered via Electron's \`globalShortcut\`, it is intercepted at the OS level before any key event reaches the renderer or xterm.

This causes two well-known issues:
1. Users who assign \`Ctrl+Space\` to a terminal-local hotkey see nothing happen — the global shortcut consumes the key first.
2. On Linux, \`Ctrl+Space\` is the standard IME toggle shortcut (ibus, fcitx), making it a poor default that conflicts with input methods.

Reported repeatedly: #540, #683, #2809, and most recently #11281.

## Fix

Remove \`Ctrl+Space\` from the platform defaults for \`toggle-window\`. Users who want a global toggle shortcut can assign one manually in Settings → Hotkeys.

## Test plan

- [ ] Verify \`toggle-window\` has no default hotkey after config reset
- [ ] Verify manually assigning a hotkey to \`toggle-window\` still works
- [ ] Verify \`Ctrl+Space\` assigned to a terminal-local hotkey now fires correctly
- [ ] Verify no regressions in \`new-window\` defaults (unchanged)