### PR TITLE
feat: add Connect, Disconnect, and Reconnect buttons to serial tab toolbar

### DIFF
--- a/tabby-serial/src/components/serialTab.component.pug
+++ b/tabby-serial/src/components/serialTab.component.pug
@@ -8,6 +8,14 @@ terminal-toolbar([tab]='this')
     button.btn.btn-sm.btn-link.me-3((click)='changeBaudRate()', *ngIf='session && session.open && hostApp.platform !== Platform.Web')
         span(translate) Change baud rate
 
-    button.btn.btn-sm.btn-link((click)='reconnect()', *ngIf='!session || !session.open')
+    button.btn.btn-sm.btn-link.me-2((click)='disconnect()', *ngIf='session && session.open')
+        i.fas.fa-times
+        span(translate) Disconnect
+
+    button.btn.btn-sm.btn-link((click)='reconnect()', *ngIf='session && session.open')
         i.fas.fa-redo
         span(translate) Reconnect
+
+    button.btn.btn-sm.btn-link((click)='reconnect()', *ngIf='!session || !session.open')
+        i.fas.fa-plug
+        span(translate) Connect


### PR DESCRIPTION
## Summary

Adds three connection-control buttons to the serial port tab toolbar, as requested in #11152.

| State | Buttons shown |
|-------|--------------|
| Port open | **Disconnect** · **Reconnect** |
| Port closed | **Connect** |

No changes to component logic — \`disconnect()\` and \`reconnect()\` are already provided by \`ConnectableTerminalTabComponent\`. This is a pure template change.

## Motivation

IoT/embedded developers frequently need to release the serial port (e.g. to flash firmware) and reconnect without leaving Tabby. Previously this required right-clicking for the context menu. The toolbar buttons make this one click.

## Test plan

- [ ] Open a serial profile — toolbar shows **Connect** when port is closed
- [ ] After connecting — toolbar shows **Disconnect** and **Reconnect**
- [ ] **Disconnect** closes the port; toolbar reverts to **Connect**
- [ ] **Reconnect** cycles the connection without closing the tab
- [ ] **Change baud rate** button still appears when connected (unchanged)

Closes #11152