### PR TITLE
fix: replace exec() with execFile() to prevent shell injection in app.ts

### DIFF
--- a/app/lib/app.ts
+++ b/app/lib/app.ts
@@ -2,7 +2,7 @@ import { app, ipcMain, Menu, Tray, shell, screen, globalShortcut, MenuItemConstr
 import promiseIpc from 'electron-promise-ipc'
 import * as remote from '@electron/remote/main'
 import { spawnSync } from 'child_process'
-import { exec } from 'mz/child_process'
+import { execFile } from 'mz/child_process'
 import * as path from 'path'
 import * as fs from 'fs'
 import { Subject, throttleTime } from 'rxjs'
@@ -62,7 +62,7 @@ export class Application {
 
         ;(promiseIpc as any).on('get-default-mac-shell', async () => {
             try {
-                return (await exec(`/usr/bin/dscl . -read /Users/${process.env.LOGNAME} UserShell`))[0].toString().split(' ')[1].trim()
+                return (await execFile('/usr/bin/dscl', ['.', '-read', `/Users/${process.env.LOGNAME}`, 'UserShell']))[0].toString().split(' ')[1].trim()
             } catch {
                 return '/bin/bash'
             }


### PR DESCRIPTION
## Security Fix

**Severity:** High

The \`get-default-mac-shell\` IPC handler in \`app/lib/app.ts\` passed \`process.env.LOGNAME\` directly into a shell command string given to \`exec()\`:

\`\`\`ts
// Before (vulnerable)
exec(\`/usr/bin/dscl . -read /Users/\${process.env.LOGNAME} UserShell\`)
\`\`\`

If \`LOGNAME\` contains shell metacharacters (e.g. \`; rm -rf ~\`), the shell would execute them. This is a shell injection vulnerability.

## Fix

Replaced with \`execFile()\` and an argument array — the shell is never involved:

\`\`\`ts
// After (safe)
execFile('/usr/bin/dscl', ['.', '-read', \`/Users/\${process.env.LOGNAME}\`, 'UserShell'])
\`\`\`

## Affected platforms

macOS only (the handler is guarded by the \`get-default-mac-shell\` IPC event).