### PR TITLE
fix: validate URL scheme before openExternal in linkifier

### DIFF
--- a/tabby-core/src/directives/fastHtmlBind.directive.ts
+++ b/tabby-core/src/directives/fastHtmlBind.directive.ts
@@ -20,9 +20,17 @@ export class FastHtmlBindDirective implements OnChanges {
         }
         this._lastValue = this.fastHtmlBind
         this.el.nativeElement.innerHTML = this.fastHtmlBind ?? ''
+        const allowedSchemes = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
         for (const link of this.el.nativeElement.querySelectorAll('a')) {
             link.addEventListener('click', event => {
                 event.preventDefault()
+                try {
+                    if (!allowedSchemes.includes(new URL(link.href).protocol)) {
+                        return
+                    }
+                } catch {
+                    return
+                }
                 this.platform.openExternal(link.href)
             })
         }

--- a/tabby-core/src/directives/fastHtmlBind.directive.ts
+++ b/tabby-core/src/directives/fastHtmlBind.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, ElementRef, OnChanges } from '@angular/core'
 import { PlatformService } from '../api/platform'
+import { isURLSchemeAllowed } from '../utils'
 
 /** @hidden */
 @Directive({
@@ -20,15 +21,10 @@ export class FastHtmlBindDirective implements OnChanges {
         }
         this._lastValue = this.fastHtmlBind
         this.el.nativeElement.innerHTML = this.fastHtmlBind ?? ''
-        const allowedSchemes = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
         for (const link of this.el.nativeElement.querySelectorAll('a')) {
             link.addEventListener('click', event => {
                 event.preventDefault()
-                try {
-                    if (!allowedSchemes.includes(new URL(link.href).protocol)) {
-                        return
-                    }
-                } catch {
+                if (!isURLSchemeAllowed(link.href)) {
                     return
                 }
                 this.platform.openExternal(link.href)

--- a/tabby-core/src/utils.ts
+++ b/tabby-core/src/utils.ts
@@ -7,6 +7,25 @@ export const WIN_BUILD_CONPTY_STABLE = 18309
 export const WIN_BUILD_WSL_EXE_DISTRO_FLAG = 17763
 export const WIN_BUILD_FLUENT_BG_SUPPORTED = 17063
 
+/**
+ * URL schemes that are safe to hand off to the OS via openExternal().
+ * Anything else (e.g. file:, data:, custom protocols printed by a remote
+ * host) must never be opened automatically.
+ */
+export const ALLOWED_EXTERNAL_URL_SCHEMES = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
+
+/**
+ * Returns true if the given URL uses a scheme that is safe to open externally.
+ * Unparseable URLs are rejected.
+ */
+export function isURLSchemeAllowed (url: string): boolean {
+    try {
+        return ALLOWED_EXTERNAL_URL_SCHEMES.includes(new URL(url).protocol)
+    } catch {
+        return false
+    }
+}
+
 export function getWindows10Build (): number|undefined {
     return process.platform === 'win32' && parseFloat(os.release()) >= 10 ? parseInt(os.release().split('.')[2]) : undefined
 }

--- a/tabby-linkifier/src/decorator.ts
+++ b/tabby-linkifier/src/decorator.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core'
-import { ConfigService, PlatformService } from 'tabby-core'
+import { ConfigService, PlatformService, isURLSchemeAllowed } from 'tabby-core'
 import { TerminalDecorator, BaseTerminalTabComponent, XTermFrontend } from 'tabby-terminal'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { LinkHandler } from './api'
@@ -20,17 +20,12 @@ export class LinkHighlighterDecorator extends TerminalDecorator {
             return
         }
 
-        const allowedSchemes = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
         tab.frontend.xterm.options.linkHandler = {
             activate: (event, uri) => {
                 if (!this.willHandleEvent(event)) {
                     return
                 }
-                try {
-                    if (!allowedSchemes.includes(new URL(uri).protocol)) {
-                        return
-                    }
-                } catch {
+                if (!isURLSchemeAllowed(uri)) {
                     return
                 }
                 this.platform.openExternal(uri)

--- a/tabby-linkifier/src/decorator.ts
+++ b/tabby-linkifier/src/decorator.ts
@@ -20,9 +20,17 @@ export class LinkHighlighterDecorator extends TerminalDecorator {
             return
         }
 
+        const allowedSchemes = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
         tab.frontend.xterm.options.linkHandler = {
             activate: (event, uri) => {
                 if (!this.willHandleEvent(event)) {
+                    return
+                }
+                try {
+                    if (!allowedSchemes.includes(new URL(uri).protocol)) {
+                        return
+                    }
+                } catch {
                     return
                 }
                 this.platform.openExternal(uri)

--- a/tabby-linkifier/src/handlers.ts
+++ b/tabby-linkifier/src/handlers.ts
@@ -21,6 +21,14 @@ export class URLHandler extends LinkHandler {
     }
 
     handle (uri: string): void {
+        const allowed = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
+        try {
+            if (!allowed.includes(new URL(uri).protocol)) {
+                return
+            }
+        } catch {
+            return
+        }
         this.platform.openExternal(uri)
     }
 }

--- a/tabby-linkifier/src/handlers.ts
+++ b/tabby-linkifier/src/handlers.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import untildify from 'untildify'
 import { Injectable } from '@angular/core'
 import { ToastrService } from 'ngx-toastr'
-import { PlatformService } from 'tabby-core'
+import { PlatformService, isURLSchemeAllowed } from 'tabby-core'
 import { BaseTerminalTabComponent } from 'tabby-terminal'
 
 import { LinkHandler } from './api'
@@ -21,12 +21,7 @@ export class URLHandler extends LinkHandler {
     }
 
     handle (uri: string): void {
-        const allowed = ['http:', 'https:', 'ftp:', 'mailto:', 'ssh:']
-        try {
-            if (!allowed.includes(new URL(uri).protocol)) {
-                return
-            }
-        } catch {
+        if (!isURLSchemeAllowed(uri)) {
             return
         }
         this.platform.openExternal(uri)


### PR DESCRIPTION
## Security Fix

Severity: Medium

The linkifier URLHandler and xterm built-in linkHandler called openExternal() with any URL matched from terminal output, without validating the scheme. The URL regex accepts any 3-9 letter scheme, so a malicious SSH server could print a file://, data:, or custom protocol URL and have it opened when the user clicks it.

A similar unchecked openExternal() call existed in fastHtmlBind for HTML-rendered links.

## Fix

Added an allowlist check (http, https, ftp, mailto, ssh) before invoking openExternal().

Files changed:
- tabby-linkifier/src/handlers.ts — URLHandler.handle()
- tabby-linkifier/src/decorator.ts — xterm linkHandler.activate
- tabby-core/src/directives/fastHtmlBind.directive.ts — rendered HTML link clicks

Note: IPHandler (prepends http://) and BaseFileHandler (prepends file://) are intentional and unchanged.