### PR TITLE
fix: show persistent activity indicator on background tab when bell fires

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -434,6 +434,9 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             if (this.config.store.terminal.bell === 'audible') {
                 this.bellPlayer.play()
             }
+            if (!this.hasFocus) {
+                this.displayActivity()
+            }
         })
 
         this.frontend.focus()


### PR DESCRIPTION
## Problem

When a bell (`\a`) fires in a background tab, the tab header activity indicator (blue dot) briefly appears then disappears, making it easy to miss which tab had activity if you weren't watching at that exact moment. Related: #11172

## Root cause

The bell subscriber in `BaseTerminalTabComponent` handled visual/audible output but never called `displayActivity()`. The activity indicator was only triggered indirectly via `binaryOutput$` (which has a 1-second startup delay and can be affected by timing).

## Fix

Call `displayActivity()` inside the bell handler when the tab does not have focus. The indicator then persists on the tab header until the user clicks that tab, at which point `clearActivity()` is called automatically via the existing tab-switch logic — consistent with how other terminal output already marks activity.

## Behavior

- Bell fires in background tab → blue dot appears on tab header and stays visible
- User focuses that tab → indicator clears (existing behavior, no change)
- Bell fires in the currently focused tab → no indicator shown (tab is already in view)