### PR TITLE
fix: Plugins search

### DIFF
--- a/tabby-core/src/api/mainProcess.ts
+++ b/tabby-core/src/api/mainProcess.ts
@@ -11,6 +11,7 @@ export interface PluginInfo {
     homepage?: string
     path?: string
     info?: any
+    searchScore?: number
 }
 
 export interface BootstrapData {

--- a/tabby-plugin-manager/src/services/pluginManager.service.ts
+++ b/tabby-plugin-manager/src/services/pluginManager.service.ts
@@ -41,7 +41,7 @@ export class PluginManagerService {
                     return true
                 })
             }),
-            map(x => x.sort((a, b) => a.name.localeCompare(b.name))),
+            map(x => x.sort((a, b) => b.searchScore - a.searchScore)),
         )
     }
 
@@ -63,6 +63,7 @@ export class PluginManagerService {
                     homepage: item.package.links.homepage,
                     author: item.package.author?.name,
                     isOfficial: item.package.publisher.username === OFFICIAL_NPM_ACCOUNT,
+                    searchScore: item.searchScore,
                 })),
             ),
             map(plugins => plugins.filter(x => x.packageName.startsWith(namePrefix))),

--- a/tabby-plugin-manager/src/services/pluginManager.service.ts
+++ b/tabby-plugin-manager/src/services/pluginManager.service.ts
@@ -41,7 +41,7 @@ export class PluginManagerService {
                     return true
                 })
             }),
-            map(x => x.sort((a, b) => b.searchScore - a.searchScore)),
+            map(x => x.sort((a, b) => b.searchScore! - a.searchScore!)),
         )
     }
 


### PR DESCRIPTION
## Summary
Plugin search results were sorted alphabetically, causing relevant matches to be buried.
Updated plugin search results to be sorted by npm searchScore.

<img width="891" height="531" alt="image" src="https://github.com/user-attachments/assets/c9746eda-b8c3-4bb9-84dc-7fb2fa34ec85" />
