### PR TITLE
fix(ssh): prevent keepalive flooding by mapping null/0 keepaliveInterval to undefined

### DIFF
--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -426,7 +426,7 @@ export class SSHSession {
                     key: this.profile.options.algorithms[SSHAlgorithmType.HOSTKEY].filter(x => supportedAlgorithms[SSHAlgorithmType.HOSTKEY].includes(x)),
                     compression: this.profile.options.algorithms[SSHAlgorithmType.COMPRESSION].filter(x => supportedAlgorithms[SSHAlgorithmType.COMPRESSION].includes(x)),
                 },
-                keepaliveIntervalSeconds: Math.round(this.profile.options.keepaliveInterval / 1000),
+                keepaliveIntervalSeconds: this.profile.options.keepaliveInterval ? Math.round(this.profile.options.keepaliveInterval / 1000) : undefined,
                 keepaliveCountMax: this.profile.options.keepaliveCountMax,
                 connectionTimeoutSeconds: this.profile.options.readyTimeout ? Math.round(this.profile.options.readyTimeout / 1000) : undefined,
             },


### PR DESCRIPTION
Hi,
this PR fixes #11302.
### Root Cause
An old profile (loaded from `localStorage.tabsRecovery`) can have `this.profile.options.keepaliveInterval` set to `null` (whereas a new profile defaults to `5000`).
In the current code:
`keepaliveIntervalSeconds: Math.round(this.profile.options.keepaliveInterval / 1000)`
Evaluating this with `null` yields `0` instead of `undefined` in javascript. 
Passing `0` will get `Some(Duration::from_secs(0))` in `russh`, which causes tabby to flood the ssh server with keepalive packets and leads to an immediate ssh `session closed`.
### Solution
This fix maps `null`, `undefined`, or `0` representing disabled keepalives to `undefined`, preventing packet flooding and resolving the disconnect loop.