### PR TITLE
fix: honour vault passphrase remember duration and clarify unlock modal

### DIFF
--- a/locale/app.pot
+++ b/locale/app.pot
@@ -1702,7 +1702,11 @@ msgid "Release notes"
 msgstr ""
 
 #: locale/tmp-html/tabby-core/src/components/unlockVaultModal.component.html:6
-msgid "Remember for {time}"
+msgid "Remember for {time} while Tabby is open"
+msgstr ""
+
+#: locale/tmp-html/tabby-core/src/components/unlockVaultModal.component.html:12
+msgid "The master passphrase is kept in memory only. Closing Tabby requires unlocking the vault again."
 msgstr ""
 
 #: locale/tmp-html/tabby-ssh/src/components/sshPortForwardingConfig.component.html:41

--- a/tabby-core/src/components/unlockVaultModal.component.pug
+++ b/tabby-core/src/components/unlockVaultModal.component.pug
@@ -5,7 +5,7 @@
             button.btn.btn-link(ngbDropdownToggle, (click)='$event.stopPropagation()')
                 span(
                     *ngIf='rememberFor',
-                    translate='Remember for {time}',
+                    translate='Remember for {time} while Tabby is open',
                     [translateParams]='{time: getRememberForDisplay(rememberFor)}'
                 )
                 span(*ngIf='!rememberFor', translate) Do not remember
@@ -18,6 +18,9 @@
                     *ngFor='let x of rememberOptions',
                     (click)='rememberFor = x',
                 ) {{getRememberForDisplay(x)}}
+
+    .text-muted.small.mb-3(translate)
+        | The master passphrase is kept in memory only. Closing Tabby requires unlocking the vault again.
 
     .input-group
         input.form-control.form-control-lg(

--- a/tabby-core/src/components/unlockVaultModal.component.ts
+++ b/tabby-core/src/components/unlockVaultModal.component.ts
@@ -16,7 +16,13 @@ export class UnlockVaultModalComponent {
     ) { }
 
     ngOnInit (): void {
-        this.rememberFor = parseInt(window.localStorage.vaultRememberPassphraseFor ?? 0)
+        const stored = window.localStorage.vaultRememberPassphraseFor
+        if (stored === undefined || stored === null || stored === '') {
+            this.rememberFor = 1
+        } else {
+            const parsed = parseInt(stored, 10)
+            this.rememberFor = isNaN(parsed) ? 1 : parsed
+        }
         setTimeout(() => {
             this.input.nativeElement.focus()
         })

--- a/tabby-core/src/services/vault.service.ts
+++ b/tabby-core/src/services/vault.service.ts
@@ -179,11 +179,11 @@ export class VaultService {
         if (!_rememberedPassphrase) {
             const modal = this.ngbModal.open(UnlockVaultModalComponent)
             const { passphrase, rememberFor } = await modal.result
+            _rememberedPassphrase = passphrase
             setTimeout(() => {
                 _rememberedPassphrase = null
                 // avoid multiple consequent prompts
-            }, Math.max(1000, rememberFor * 60000))
-            _rememberedPassphrase = passphrase
+            }, rememberFor > 0 ? rememberFor * 60000 : 1000)
         }
 
         return _rememberedPassphrase!

--- a/tabby-core/src/services/vault.service.ts
+++ b/tabby-core/src/services/vault.service.ts
@@ -183,11 +183,11 @@ export class VaultService {
                 throw new Error('Vault unlock cancelled')
             }
             const { passphrase, rememberFor } = result
+            _rememberedPassphrase = passphrase
             setTimeout(() => {
                 _rememberedPassphrase = null
                 // avoid multiple consequent prompts
-            }, Math.max(1000, rememberFor * 60000))
-            _rememberedPassphrase = passphrase
+            }, rememberFor > 0 ? rememberFor * 60000 : 1000)
         }
 
         return _rememberedPassphrase!


### PR DESCRIPTION
Addresses #9753

## Problem

People keep reporting that vault "Remember for 7 days" doesn't work — unlock once, close Tabby, reopen, and the passphrase prompt is back (#9753). Same complaint shows up across several versions in that thread.

After going through the comments, it's two different things. Eugeny already pointed out that the passphrase isn't written to disk; it only stays in memory while Tabby is running. A lot of users didn't realise that because the UI doesn't say it. There's also a separate bug where remember could fail within the same session.

## Root cause

When no duration was saved in `localStorage` yet, unlock modal init did:

```ts
parseInt(window.localStorage.vaultRememberPassphraseFor ?? 0)
```

So the first time through, that became `0` ("Do not remember"). `VaultService` then cleared the cached passphrase after one second (`Math.max(1000, 0)`), even if the user thought they'd picked a longer duration from the dropdown.

The "Remember for {time}" label also reads like it survives an app restart, which isn't how the vault works today.

## Fix

- Default to 1 minute when nothing is stored in `localStorage` yet. Keep `0` when the user explicitly picks "Do not remember".
- Only use the long timeout for `rememberFor > 0`; keep the 1-second cache for the explicit "do not remember" case (same as before, for concurrent unlock calls).
- Change the dropdown text to "Remember for {time} while Tabby is open" and add a line under it: closing Tabby means unlocking the vault again.

## Note

Passphrase storage is unchanged — memory only, no keychain or cross-restart persistence. If that's wanted later, it's a different change.

Files changed:
- `tabby-core/src/components/unlockVaultModal.component.ts`
- `tabby-core/src/services/vault.service.ts`
- `tabby-core/src/components/unlockVaultModal.component.pug`
- `locale/app.pot`