### PR TITLE
feat(terminal): add insert-new-line hotkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ sentry-symbols.js
 
 crowdin.yml
 .crowdin.env
+
+CLAUDE.md

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -306,6 +306,11 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                         }[this.hostApp.platform])
                     })
                     break
+                case 'insert-new-line':
+                    this.forEachFocusedTerminalPane(tab => {
+                        tab.sendInput('\x1b\r')
+                    })
+                    break
                 case 'copy-current-path':
                     this.copyCurrentPath()
                     break

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -103,6 +103,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'focus-all-tabs': [
                     '⌘-⌥-Shift-I',
                 ],
+                'insert-new-line': ['⌥-Shift-Enter'],
                 'scroll-to-top': ['Shift-PageUp'],
                 'scroll-page-up': ['⌥-PageUp'],
                 'scroll-up': ['Ctrl-Shift-Up'],
@@ -156,6 +157,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'focus-all-tabs': [
                     'Ctrl-Alt-Shift-I',
                 ],
+                'insert-new-line': ['Alt-Shift-Enter'],
                 'scroll-to-top': ['Ctrl-PageUp'],
                 'scroll-page-up': ['Alt-PageUp'],
                 'scroll-up': ['Ctrl-Shift-Up'],
@@ -207,6 +209,7 @@ export class TerminalConfigProvider extends ConfigProvider {
                 'focus-all-tabs': [
                     'Ctrl-Alt-Shift-I',
                 ],
+                'insert-new-line': ['Alt-Shift-Enter'],
                 'scroll-to-top': ['Ctrl-PageUp'],
                 'scroll-page-up': ['Alt-PageUp'],
                 'scroll-up': ['Ctrl-Shift-Up'],

--- a/tabby-terminal/src/hotkeys.ts
+++ b/tabby-terminal/src/hotkeys.ts
@@ -113,6 +113,10 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
             id: 'disconnect-tab',
             name: this.translate.instant('Disconnect current tab (Serial/Telnet/SSH)'),
         },
+        {
+            id: 'insert-new-line',
+            name: this.translate.instant('Insert new line'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }
@@ -121,4 +125,3 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
         return this.hotkeys
     }
 }
-


### PR DESCRIPTION
## Summary

- Adds a new `insert-new-line` hotkey that sends `\x1b\r` (ESC + CR) to the terminal
- Default binding: `⌥-Shift-Enter` on macOS, `Alt-Shift-Enter` on Linux/Windows
- Useful for inserting a literal newline in shells that support multiline input (e.g. fish, zsh with multiline mode)