### PR TITLE
fix(ssh): allow blank passwords in profile and keychain auth

### DIFF
--- a/tabby-ssh/src/components/keyboardInteractiveAuthPanel.component.ts
+++ b/tabby-ssh/src/components/keyboardInteractiveAuthPanel.component.ts
@@ -34,7 +34,7 @@ export class KeyboardInteractiveAuthComponent implements OnInit {
 
     async ngOnInit (): Promise<void> {
         const savedPassword = await this.passwordStorage.loadPassword(this.profile)
-        if (savedPassword) {
+        if (savedPassword != null) {
             for (let i = 0; i < this.prompt.prompts.length; i++) {
                 if (this.prompt.isAPasswordPrompt(i) && !this.prompt.responses[i]) {
                     this.prompt.responses[i] = savedPassword

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -57,7 +57,7 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
 
         if (this.profile.options.user) {
             try {
-                this.hasSavedPassword = !!await this.passwordStorage.loadPassword(this.profile)
+                this.hasSavedPassword = (await this.passwordStorage.loadPassword(this.profile)) != null
             } catch (e) {
                 console.error('Could not check for saved password', e)
             }
@@ -74,7 +74,7 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
         modal.componentInstance.password = true
         try {
             const result = await modal.result.catch(() => null)
-            if (result?.value) {
+            if (result != null) {
                 this.passwordStorage.savePassword(this.profile, result.value)
                 this.hasSavedPassword = true
             }

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -75,7 +75,9 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
         modal.componentInstance.password = true
         try {
             const result = await modal.result.catch(() => null)
-            if (result != null) {
+            // Allow saving a blank password (empty string), but guard against a
+            // malformed modal result that carries no string value.
+            if (typeof result?.value === 'string') {
                 this.passwordStorage.savePassword(this.profile, result.value)
                 this.hasSavedPassword = true
             }

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -57,7 +57,8 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
 
         if (this.profile.options.user) {
             try {
-                this.hasSavedPassword = (await this.passwordStorage.loadPassword(this.profile)) != null
+                const savedPassword = await this.passwordStorage.loadPassword(this.profile)
+                this.hasSavedPassword = savedPassword != null
             } catch (e) {
                 console.error('Could not check for saved password', e)
             }

--- a/tabby-ssh/src/services/ssh.service.ts
+++ b/tabby-ssh/src/services/ssh.service.ts
@@ -40,7 +40,7 @@ export class SSHService {
             uri += `;x-tunnelusername=${jumpUsername}`
             if (jumpHostProfile.options.auth === 'password') {
                 const jumpPassword = await this.passwordStorage.loadPassword(jumpHostProfile, jumpUsername)
-                if (jumpPassword) {
+                if (jumpPassword != null) {
                     uri += `;x-tunnelpasswordplain=${encodeURIComponent(jumpPassword)}`
                 }
             }
@@ -61,7 +61,7 @@ export class SSHService {
     async getWinSCPURI (profile: SSHProfile, cwd?: string, username?: string): Promise<{ uri: string, privateKeyFile?: tmp.FileResult|null }> {
         let uri = `scp://${username ?? profile.options.user}`
         const password = await this.passwordStorage.loadPassword(profile, username)
-        if (password) {
+        if (password != null) {
             uri += ':' + encodeURIComponent(password)
         }
         let tmpFile: tmp.FileResult|null = null

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -245,12 +245,12 @@ export class SSHSession {
             }
         }
         if (!this.profile.options.auth || this.profile.options.auth === 'password') {
-            if (this.profile.options.password) {
+            if (this.profile.options.password != null) {
                 this.allAuthMethods.push({ type: 'saved-password', password: this.profile.options.password })
             }
         }
         if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive') {
-            if (this.profile.options.password) {
+            if (this.profile.options.password != null) {
                 this.allAuthMethods.push({ type: 'keyboard-interactive', savedPassword: this.profile.options.password })
             }
             this.allAuthMethods.push({ type: 'keyboard-interactive' })
@@ -267,7 +267,7 @@ export class SSHSession {
         }
 
         const storedPassword = await this.passwordStorage.loadPassword(this.profile, this.authUsername)
-        if (!storedPassword) {
+        if (storedPassword == null) {
             return
         }
 
@@ -486,7 +486,7 @@ export class SSHSession {
 
         // auth success
 
-        if (this.savedPassword) {
+        if (this.savedPassword != null) {
             this.passwordStorage.savePassword(this.profile, this.savedPassword, this.authUsername ?? undefined)
         }
 
@@ -682,7 +682,7 @@ export class SSHSession {
                 modal.componentInstance.password = true
                 modal.componentInstance.showRememberCheckbox = true
                 const prefilledPassword = await this.passwordStorage.loadPassword(this.profile, this.authUsername)
-                if (prefilledPassword) {
+                if (prefilledPassword != null) {
                     modal.componentInstance.value = prefilledPassword
                 }
 
@@ -739,7 +739,7 @@ export class SSHSession {
                             state.prompts(),
                         )
 
-                        if (method.savedPassword) {
+                        if (method.savedPassword != null) {
                             // eslint-disable-next-line max-depth
                             for (let i = 0; i < prompt.prompts.length; i++) {
                                 // eslint-disable-next-line max-depth

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -245,12 +245,12 @@ export class SSHSession {
             }
         }
         if (!this.profile.options.auth || this.profile.options.auth === 'password') {
-            if (this.profile.options.password != null) {
+            if (typeof this.profile.options.password === 'string') {
                 this.allAuthMethods.push({ type: 'saved-password', password: this.profile.options.password })
             }
         }
         if (!this.profile.options.auth || this.profile.options.auth === 'keyboardInteractive') {
-            if (this.profile.options.password != null) {
+            if (typeof this.profile.options.password === 'string') {
                 this.allAuthMethods.push({ type: 'keyboard-interactive', savedPassword: this.profile.options.password })
             }
             this.allAuthMethods.push({ type: 'keyboard-interactive' })


### PR DESCRIPTION
## Problem

SSH password authentication fails immediately when the password is blank,
even though OpenSSH accepts empty passwords on some hosts (e.g. lab machines).

## Root cause

Password handling used truthy checks (`if (password)`, `if (!storedPassword)`).
An empty string is falsy in JavaScript, so blank passwords were never saved
to the keychain, never loaded into auth methods, and never sent during login.

## Fix

Use explicit null/undefined checks (`!= null` / `== null`) everywhere a stored
or configured password may legitimately be an empty string.

## Testing

- `tabby-ssh` webpack build passes

Addresses #11312