### PR TITLE
fix(ssh): close tab when SSH session ends via Ctrl+D

### DIFF
--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -229,7 +229,7 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
 
     protected isSessionExplicitlyTerminated (): boolean {
         return super.isSessionExplicitlyTerminated() ||
-        this.recentInputs.charCodeAt(this.recentInputs.length - 1) === 4 ||
-        this.recentInputs.endsWith('exit\r')
+        this.recentInputs.endsWith('exit\r') ||
+        this.recentInputs.endsWith('logout\r')
     }
 }

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -137,7 +137,6 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
     protected binaryOutput = new Subject<Buffer>()
     protected sessionChanged = new Subject<BaseSession|null>()
     protected recentInputs = ''
-    protected userSentEOT = false
     private bellPlayer: HTMLAudioElement
     private termContainerSubscriptions = new SubscriptionContainer()
     private sessionHandlers = new SubscriptionContainer()
@@ -764,7 +763,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                 this.setSession(null)
             }
             this.detachSessionHandlers()
-            this.userSentEOT = false
+            this.recentInputs = ''
             this.session = session
             this.attachSessionHandlers(destroyOnSessionClose)
         } else {
@@ -912,15 +911,15 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
      * Return true if the user explicitly exit the session
      */
     protected isSessionExplicitlyTerminated (): boolean {
-        return this.userSentEOT
+        // EOT (Ctrl+D) as the most recent keystroke means the user asked the
+        // shell to exit. Checking the trailing byte (rather than "ever seen")
+        // avoids false positives when Ctrl+D is used for EOF inside a pager,
+        // REPL, etc. and the session later ends for an unrelated reason.
+        return this.recentInputs.endsWith('\x04')
     }
 
     protected recordRecentInput (data: Buffer): void {
-        const chunk = data.toString('latin1')
-        this.recentInputs += chunk
+        this.recentInputs += data.toString('latin1')
         this.recentInputs = this.recentInputs.substring(this.recentInputs.length - 32)
-        if (chunk.includes('\x04')) {
-            this.userSentEOT = true
-        }
     }
 }

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -137,6 +137,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
     protected binaryOutput = new Subject<Buffer>()
     protected sessionChanged = new Subject<BaseSession|null>()
     protected recentInputs = ''
+    protected userSentEOT = false
     private bellPlayer: HTMLAudioElement
     private termContainerSubscriptions = new SubscriptionContainer()
     private sessionHandlers = new SubscriptionContainer()
@@ -464,8 +465,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
         }
 
         this.input$.subscribe(data => {
-            this.recentInputs += data
-            this.recentInputs = this.recentInputs.substring(this.recentInputs.length - 32)
+            this.recordRecentInput(data)
         })
     }
 
@@ -764,6 +764,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                 this.setSession(null)
             }
             this.detachSessionHandlers()
+            this.userSentEOT = false
             this.session = session
             this.attachSessionHandlers(destroyOnSessionClose)
         } else {
@@ -911,6 +912,15 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
      * Return true if the user explicitly exit the session
      */
     protected isSessionExplicitlyTerminated (): boolean {
-        return false
+        return this.userSentEOT
+    }
+
+    protected recordRecentInput (data: Buffer): void {
+        const chunk = data.toString('latin1')
+        this.recentInputs += chunk
+        this.recentInputs = this.recentInputs.substring(this.recentInputs.length - 32)
+        if (chunk.includes('\x04')) {
+            this.userSentEOT = true
+        }
     }
 }

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -59,7 +59,6 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     async initializeSession (): Promise<void> {
         this.reconnectOffered = false
         this.isDisconnectedByHand = false
-        this.userSentEOT = false
     }
 
     /**

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -59,6 +59,7 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     async initializeSession (): Promise<void> {
         this.reconnectOffered = false
         this.isDisconnectedByHand = false
+        this.userSentEOT = false
     }
 
     /**


### PR DESCRIPTION
## Problem
With default "Auto" session-end behavior, pressing Ctrl+D ends the SSH
shell but the tab often stays open instead of closing.

## Root cause
Explicit-termination detection relied on the last character of
`recentInputs` matching EOT (0x04). Buffer-to-string coercion was
unreliable, so Ctrl+D was missed and `shouldTabBeDestroyedOnSessionClose()`
returned false.

## Fix
Track a `userSentEOT` flag when terminal input contains `\x04`, decode
recent input as latin1, and treat that flag as explicit termination for
auto-close. Also recognize `logout\r` for SSH alongside `exit\r`.

## Testing
- tabby-terminal and tabby-ssh webpack builds pass
- ESLint pass
- Manual test: Ctrl+D closes SSH tabs as expected

Addresses #11044