### PR TITLE
fix(terminal): reset stale DEC modes on connectable reconnect

### DIFF
--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -117,6 +117,7 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
 
     async reconnect (): Promise<void> {
         this.session?.destroy()
+        this.frontend?.resetTerminalModes()
         await this.initializeSession()
         this.clearServiceMessagesOnConnect()
         this.session?.releaseInitialDataBuffer()

--- a/tabby-terminal/src/frontends/frontend.ts
+++ b/tabby-terminal/src/frontends/frontend.ts
@@ -93,4 +93,10 @@ export abstract class Frontend {
 
     abstract supportsBracketedPaste (): boolean
     abstract isAlternateScreenActive (): boolean
+
+    /**
+     * Reset terminal modes (mouse tracking, bracketed paste, etc.)
+     * Called on session reconnection to prevent stale modes from leaking
+     */
+    resetTerminalModes (): void { } // eslint-disable-line
 }

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -441,6 +441,15 @@ export class XTermFrontend extends Frontend {
         this.xterm.clear()
     }
 
+    resetTerminalModes (): void {
+        // Disable mouse tracking modes (normal, button-event, any-event)
+        // and SGR extended mouse mode to prevent stale mouse tracking
+        // from leaking escape sequences as text after session reconnection
+        this.xterm.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l')
+        // Disable bracketed paste mode
+        this.xterm.write('\x1b[?2004l')
+    }
+
     visualBell (): void {
         if (this.element) {
             this.element.style.animation = 'none'


### PR DESCRIPTION
Connectable tabs (SSH and similar) reuse the same xterm.js frontend when a session ends and a new one is created. If the remote side had enabled mouse tracking (e.g. DECSET 1006 SGR coordinates) or bracketed paste (2004) and the connection dropped before a clean shutdown, those modes could remain active in the emulator. The user would then see mouse-driven input as literal text (e.g. coordinate fragments after right-click/paste).

After destroying the old session, call resetTerminalModes() so the parser applies DECRST for mouse modes and bracketed paste before the new session attaches. The base Frontend provides a no-op; XTermFrontend writes the standard escape sequences to xterm.

<img width="1785" height="43" alt="image" src="https://github.com/user-attachments/assets/576916b9-f0dd-4fdf-9b80-d00478fee08f" />
