### PR TITLE
fix: Pin Windows build runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
       if: matrix.build-arch == 'x64'
 
   Windows-Build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: Lint
     strategy:
       matrix:


### PR DESCRIPTION
issue: #11369 
