### PR TITLE
fix: Restore hotkey edit and remove actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
       if: matrix.build-arch == 'x64'
 
   Windows-Build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: Lint
     strategy:
       matrix:

--- a/tabby-settings/src/components/multiHotkeyInput.component.pug
+++ b/tabby-settings/src/components/multiHotkeyInput.component.pug
@@ -1,8 +1,8 @@
 .item(*ngFor='let hotkey of hotkeys; let i = index')
-    .body((click)='editItem(i)')
+    .body((mousedown)='editItem(i, $event)')
         .stroke(*ngFor='let stroke of castAny(hotkey.strokes)')
             span(*ngIf='!hotkey.isDuplicate') {{stroke}}
             span.duplicate(*ngIf='hotkey.isDuplicate') {{stroke}}
-    .remove((click)='removeItem(i)') &times;
+    .remove((mousedown)='removeItem(i, $event)') &times;
 
 .add((click)='addItem()', translate) Add...

--- a/tabby-settings/src/components/multiHotkeyInput.component.scss
+++ b/tabby-settings/src/components/multiHotkeyInput.component.scss
@@ -28,6 +28,7 @@
 .add {
     flex: auto;
     opacity: 0;
+    white-space: nowrap;
 
     &:first-child {
         opacity: 1;

--- a/tabby-settings/src/components/multiHotkeyInput.component.ts
+++ b/tabby-settings/src/components/multiHotkeyInput.component.ts
@@ -22,7 +22,8 @@ export class MultiHotkeyInputComponent {
         this.hotkeys = this.hotkeys.map(hotkey => typeof hotkey.strokes === 'string' ? { ...hotkey, strokes: [hotkey.strokes] } : hotkey)
     }
 
-    editItem (index: number): void {
+    editItem (index: number, event?: MouseEvent): void {
+        if (event && event.button !== 0) { return } // Ignore non-left clicks
         this.ngbModal.open(HotkeyInputModalComponent).result.then((newStrokes: string[]) => {
             if (this.hotkeys[index]) {
                 this.hotkeys[index].strokes = newStrokes
@@ -38,7 +39,8 @@ export class MultiHotkeyInputComponent {
         })
     }
 
-    removeItem (index: number): void {
+    removeItem (index: number, event?: MouseEvent): void {
+        if (event && event.button !== 0) { return } // Ignore non-left clicks
         this.hotkeys = this.hotkeys.filter((_, i) => i !== index)
         this.storeUpdatedHotkeys()
     }


### PR DESCRIPTION
This fixes a regression introduced by the mouse wheel hotkey support changes.
The Edit and Remove actions for existing hotkeys can now be clicked again.

fix: #11324 