### PR TITLE
fix(core): keep split pane visible after switching its profile

### DIFF
--- a/tabby-core/src/components/splitTab.component.ts
+++ b/tabby-core/src/components/splitTab.component.ts
@@ -561,6 +561,7 @@ export class SplitTabComponent extends BaseTabComponent implements AfterViewInit
         this.attachTabView(newTab)
         tab.parent = null
         newTab.parent = this
+        newTab.emitVisibility(this.visibility.value)
         this.recoveryStateChangedHint.next()
         this.onAfterTabAdded(newTab)
         this.updateTitle()


### PR DESCRIPTION
Thanks for Tabby! This is a small, low-risk one-line fix for #11082.

## What happens

Split a tab, then change one pane's profile (right-click the pane → **Switch profile**, or the `switch-profile` hotkey). That pane goes blank ~30 s later and stays black until the window is resized or the tab is switched away and back.

Reproduced on v1.0.234 / Windows 11 / Intel UHD 770, but it's renderer- and GPU-independent — it happens on both the WebGL and Canvas frontends, and with `--disable-gpu`.

## Root cause

`SplitTabComponent.replaceTab()` doesn't propagate the parent split's visibility to the replacement tab:

- A freshly created tab starts at `visibility = new BehaviorSubject<boolean>(false)` (`baseTab.component.ts`).
- `add()` already emits the current visibility to inserted tabs (`tab.emitVisibility(this.visibility.value)`), but `replaceTab()` — the only caller used by profile switching (`tabContextMenu.ts` → `switchTabProfile()`) — is missing the equivalent call. The parent's `visibility$` subscription only re-emits when the split's *own* visibility changes, so a tab swapped in afterwards is never covered, which is exactly why `add()` emits explicitly.
- So the new pane keeps `visibility = false`; after `INACTIVE_TAB_UNLOAD_DELAY` (30 s) the terminal runs `deactivateAfterVisibilityChange()` and zeroes every xterm `<canvas>` — even though the pane is actually on-screen.

This sits right next to the recent #11275 visibility work: same `syncTerminalVisibility` path, just a second entry point (`replaceTab`) that wasn't covered yet. It also explains why it only shows up after a split — the **Switch profile** menu item / hotkey is gated to split panes, and `replaceTab()` is its only caller.

<details>
<summary>Evidence (DevTools)</summary>

With the pane blanked, every xterm canvas layer reports `0×0` (a healthy pane is e.g. `1225×1309`):

```
xterm-text-layer 0x0
xterm-cursor-layer 0x0
xterm-selection-layer 0x0
xterm-link-layer 0x0
```

`window.dispatchEvent(new Event('resize'))` does **not** recover it (the frontend observes the pane element via `ResizeObserver`, not the window), but a real window resize does — consistent with the canvas being zeroed and only restored on an actual geometry change.
</details>

## The fix

Mirror `add()` in `replaceTab()` so the replacement tab inherits the parent split's current visibility immediately:

```ts
newTab.parent = this
newTab.emitVisibility(this.visibility.value)
```

Focus is unaffected — `replaceTab()` already emits focus via `onAfterTabAdded()` → `focus()`.

## Test plan

1. Split a terminal tab into 2 panes.
2. Right-click one pane → **Switch profile** → pick a different profile.
3. **Before:** the pane goes black after ~30 s; resizing the window restores it.
4. **After:** the pane stays rendered.

Happy to add a regression test or adjust anything if you'd prefer a different approach — thanks for taking a look!

Fixes #11082
