### PR TITLE
fix(linkifier): keep ':' ',' and '/' in clickable URL path/query

### DIFF
--- a/tabby-linkifier/src/handlers.ts
+++ b/tabby-linkifier/src/handlers.ts
@@ -12,7 +12,9 @@ import { LinkHandler } from './api'
 export class URLHandler extends LinkHandler {
     // From https://urlregex.com/
     // with "-" added to last group (https://github.com/Eugeny/tabby/issues/5611)
-    regex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((:((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{1,5})|([0-9]{1,4})))?(?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w-]*))?)(?<!;)/
+    // and ":" "," allowed in path/query + "/" in query (all RFC 3986-valid there),
+    // with trailing ".,:;" trimmed so sentence punctuation is not captured
+    regex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((:((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{1,5})|([0-9]{1,4})))?(?:\/[\+~%\/\.\w\-_:,]*)?\??(?:[\-\+=&;%@\.\w_:,\/]*)#?(?:[\.\!\/\\\w\-:,]*))?)(?<![;:,.])/
 
     priority = 5
 


### PR DESCRIPTION
## Problem

The URL handler's regex (`tabby-linkifier/src/handlers.ts`) leaves `:` and `,` out of its **path** and **query** character classes, and `/` out of its **query** class. Because the match stops at the first such character, clickable links are truncated mid-URL. Common URLs that only highlight up to the first `:` / `,`:

| URL | Highlighted today |
|---|---|
| `https://maps.example.com/maps/@40.714,-74.006,15z` | `…/maps/@40.714` |
| `https://example.com/search?q=type:issue,state:open` | `…?q=type` |
| `https://example.com/x?to=a:b/c#frag` | `…?to=a` |

All three characters are valid in those components per **RFC 3986**: the path and query allow the `,` and `:` sub-/gen-delims, and the query additionally allows `/`. They render fine in other terminals; Tabby just stops the highlight early.

## Fix

Add the missing characters to the path/query/fragment classes:

- path: `[\+~%\/\.\w\-_]` → `[\+~%\/\.\w\-_:,]`
- query: `[\-\+=&;%@\.\w_]` → `[\-\+=&;%@\.\w_:,\/]`
- fragment: `[\.\!\/\\\w-]` → `[\.\!\/\\\w\-:,]`

…and widen the end-of-match lookbehind from `(?<!;)` to `(?<![;:,.])` so a **trailing** sentence `.` `,` `:` `;` is still not captured (e.g. `see https://example.com/page, and…` highlights `https://example.com/page`, not the comma).

## Validation

There's no test suite for the linkifier regex, so I exercised the before/after regex standalone in Node:

```
BEFORE  https://maps.example.com/maps/@40.714              ❌ truncated
AFTER   https://maps.example.com/maps/@40.714,-74.006,15z  ✅ full

BEFORE  https://example.com/search?q=type                  ❌ truncated
AFTER   https://example.com/search?q=type:issue,state:open ✅ full

trailing punctuation still trimmed:
  "see https://example.com/page, and…"  → https://example.com/page   ✅
  "end https://example.com/p."          → https://example.com/p      ✅
  "(https://example.com/q)"             → https://example.com/q      ✅
```

I wasn't able to build the full Electron app locally, so this is a focused, self-contained regex change verified by running the regex itself; happy to adjust if maintainers prefer a different character set or want a unit test added.
