### PR TITLE
fix(serial): fix serial quickConnect not working

### DIFF
--- a/tabby-serial/src/profiles.ts
+++ b/tabby-serial/src/profiles.ts
@@ -2,14 +2,14 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import slugify from 'slugify'
 import deepClone from 'clone-deep'
 import { Injectable } from '@angular/core'
-import { NewTabParameters, SelectorService, HostAppService, Platform, TranslateService, ConnectableProfileProvider } from 'tabby-core'
+import { NewTabParameters, PartialProfile, SelectorService, HostAppService, Platform, TranslateService, QuickConnectProfileProvider } from 'tabby-core'
 import { SerialProfileSettingsComponent } from './components/serialProfileSettings.component'
 import { SerialTabComponent } from './components/serialTab.component'
 import { SerialService } from './services/serial.service'
 import { BAUD_RATES, SerialProfile } from './api'
 
 @Injectable({ providedIn: 'root' })
-export class SerialProfilesService extends ConnectableProfileProvider<SerialProfile> {
+export class SerialProfilesService extends QuickConnectProfileProvider<SerialProfile> {
     id = 'serial'
     name = _('Serial')
     settingsComponent = SerialProfileSettingsComponent
@@ -103,5 +103,31 @@ export class SerialProfilesService extends ConnectableProfileProvider<SerialProf
 
     getDescription (profile: SerialProfile): string {
         return profile.options.port
+    }
+
+    quickConnect (query: string): PartialProfile<SerialProfile> {
+        let port = query
+        let baudrate = 115200
+        if (query.includes('@')) {
+            baudrate = parseInt(port.split('@')[1])
+            port = port.split('@')[0]
+        }
+
+        return {
+            name: query,
+            type: 'serial',
+            options: {
+                port,
+                baudrate,
+            },
+        }
+    }
+
+    intoQuickConnectString (profile: SerialProfile): string|null {
+        let s = profile.options.port
+        if (profile.options.baudrate !== 115200) {
+            s = `${s}@${profile.options.baudrate}`
+        }
+        return s
     }
 }

--- a/tabby-serial/src/profiles.ts
+++ b/tabby-serial/src/profiles.ts
@@ -111,6 +111,9 @@ export class SerialProfilesService extends QuickConnectProfileProvider<SerialPro
         if (query.includes('@')) {
             baudrate = parseInt(port.split('@')[1])
             port = port.split('@')[0]
+        } else if (query.includes(':')) {
+            baudrate = parseInt(port.split(':')[1])
+            port = port.split(':')[0]
         }
 
         return {

--- a/tabby-serial/src/services/serial.service.ts
+++ b/tabby-serial/src/services/serial.service.ts
@@ -1,15 +1,13 @@
-import { Injectable, Injector } from '@angular/core'
+import { Injectable } from '@angular/core'
 import WSABinding from 'serialport-binding-webserialapi'
 import AbstractBinding from '@serialport/binding-abstract'
 import { autoDetect } from '@serialport/bindings-cpp'
-import { HostAppService, PartialProfile, Platform, ProfilesService } from 'tabby-core'
-import { SerialPortInfo, SerialProfile } from '../api'
-import { SerialTabComponent } from '../components/serialTab.component'
+import { HostAppService, Platform } from 'tabby-core'
+import { SerialPortInfo } from '../api'
 
 @Injectable({ providedIn: 'root' })
 export class SerialService {
     private constructor (
-        private injector: Injector,
         private hostApp: HostAppService,
     ) { }
 
@@ -27,24 +25,5 @@ export class SerialService {
             console.error('Failed to list serial ports', err)
             return []
         }
-    }
-
-    quickConnect (query: string): Promise<SerialTabComponent|null> {
-        let path = query
-        let baudrate = 115200
-        if (query.includes('@')) {
-            baudrate = parseInt(path.split('@')[1])
-            path = path.split('@')[0]
-        }
-        const profile: PartialProfile<SerialProfile> = {
-            name: query,
-            type: 'serial',
-            options: {
-                port: path,
-                baudrate: baudrate,
-            },
-        }
-        window.localStorage.lastSerialConnection = JSON.stringify(profile)
-        return this.injector.get(ProfilesService).openNewTabForProfile(profile) as Promise<SerialTabComponent|null>
     }
 }


### PR DESCRIPTION
## Summary

Fix an issue where serial `quickConnect` was not working.
To align with the SSH and Telnet implementations, the `quickConnect` logic has been moved to `tabby-serial/src/profiles.ts`.

Additionally, `quickConnect` now supports the `Device:BaudRate` format (e.g. `/dev/ttyS0:115200`) in addition to the existing `Device@BaudRate` format (e.g. `/dev/ttyS0@115200`).

## Changes

- Fix serial `quickConnect`
- Move `quickConnect` implementation to `tabby-serial/src/profiles.ts`
- Add support for the `quickConnect serial Device:BaudRate` format