### PR TITLE
Feat: Add Hotkey to toggle Option/Meta key on Mac based Systems

### DIFF
--- a/tabby-core/src/configDefaults.macos.yaml
+++ b/tabby-core/src/configDefaults.macos.yaml
@@ -96,3 +96,5 @@ hotkeys:
     - '⌘-Shift-E'
   command-selector:
     - '⌘-Shift-P'
+  switch-meta-option:
+    - '⌘-⌥-O'

--- a/tabby-core/src/hotkeys.ts
+++ b/tabby-core/src/hotkeys.ts
@@ -255,6 +255,10 @@ export class AppHotkeyProvider extends HotkeyProvider {
             id: 'pane-decrease-horizontal',
             name: this.translate.instant('Decrease horizontal split size'),
         },
+        {
+            id: 'switch-meta-option',
+            name: this.translate.instant('Switch meta option'),
+        },
     ]
 
     constructor (

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -338,6 +338,7 @@ export class XTermFrontend extends Frontend {
                     'scroll-page-down',
                     'scroll-to-top',
                     'scroll-to-bottom',
+                    'switch-meta-option',
                 ].includes(hk)),
             ).subscribe(hk => {
                 if ([
@@ -347,6 +348,15 @@ export class XTermFrontend extends Frontend {
                 ].includes(hk)) {
                     this.pinnedToBottom = false
                 }
+
+                if(hk === 'switch-meta-option') {
+                    const newValue = !this.xterm.options.macOptionIsMeta
+                    this.xterm.options.macOptionIsMeta = newValue
+                    this.configService.store.terminal.altIsMeta = newValue
+                    this.configService.save()
+                    //TODO send notification or show popup that this setting has been changed
+                }
+
                 requestAnimationFrame(() => this.updatePinnedState())
             })
 

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, filter, firstValueFrom, fromEvent, takeUntil } from 'r
 import { Injector } from '@angular/core'
 import {
     ConfigService, getCSSFontFamily, getWindows10Build, HostAppService, HotkeysService,
-    NotificationsService, Platform, PlatformService, TerminalColorScheme, ThemesService
+    NotificationsService, Platform, PlatformService, TerminalColorScheme, ThemesService,
 } from 'tabby-core'
 import { Frontend, SearchOptions, SearchState } from './frontend'
 import { Terminal, ITheme } from '@xterm/xterm'

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -1,7 +1,10 @@
 import deepEqual from 'deep-equal'
 import { BehaviorSubject, filter, firstValueFrom, fromEvent, takeUntil } from 'rxjs'
 import { Injector } from '@angular/core'
-import { ConfigService, getCSSFontFamily, getWindows10Build, HostAppService, HotkeysService, Platform, PlatformService, TerminalColorScheme, ThemesService } from 'tabby-core'
+import {
+    ConfigService, getCSSFontFamily, getWindows10Build, HostAppService, HotkeysService,
+    NotificationsService, Platform, PlatformService, TerminalColorScheme, ThemesService
+} from 'tabby-core'
 import { Frontend, SearchOptions, SearchState } from './frontend'
 import { Terminal, ITheme } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
@@ -95,6 +98,7 @@ export class XTermFrontend extends Frontend {
     private platformService: PlatformService
     private hostApp: HostAppService
     private themes: ThemesService
+    private notifications: NotificationsService
 
     constructor (injector: Injector) {
         super(injector)
@@ -103,6 +107,7 @@ export class XTermFrontend extends Frontend {
         this.platformService = injector.get(PlatformService)
         this.hostApp = injector.get(HostAppService)
         this.themes = injector.get(ThemesService)
+        this.notifications = injector.get(NotificationsService)
 
         this.xterm = new Terminal({
             allowTransparency: true,
@@ -354,7 +359,8 @@ export class XTermFrontend extends Frontend {
                     this.xterm.options.macOptionIsMeta = newValue
                     this.configService.store.terminal.altIsMeta = newValue
                     this.configService.save()
-                    //TODO send notification or show popup that this setting has been changed
+                    const message = newValue ? 'Option Key: Meta' : 'Option Key: Normal'
+                    this.notifications.notice(message)
                 }
 
                 requestAnimationFrame(() => this.updatePinnedState())


### PR DESCRIPTION
Hey,
I tried to fix my own issue #9547 a couple of years later. The reason why I tried to fix it now is, that I didn't hat the time to look into Tabby's Source Code and implement it. The feature itself is finished and works fine, but there's missing some UI stuff. I want to ask for help regarding to the UI part, because I don't know if there is something like a popup already implemented, that can be re-used. The logic, I have commited, works, but without any UI popup or something else, it is not realy useful.


So, if someone has a specific idea how to show the this in the UI, tell me please.



Closes #9547 