### PR TITLE
fix(terminal): restart visual bell shake on repeated BEL

### DIFF
--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -485,9 +485,12 @@ export class XTermFrontend extends Frontend {
     visualBell (): void {
         if (this.element) {
             this.element.style.animation = 'none'
-            setTimeout(() => {
-                this.element!.style.animation = 'terminalShakeFrames 0.3s ease'
-            })
+            // Force a synchronous reflow so the browser registers the cleared
+            // animation before it is reassigned. Without this, repeated bells
+            // arriving while a shake is still playing coalesce into a single
+            // frame and the animation fails to restart (#11303).
+            void this.element.offsetWidth
+            this.element.style.animation = 'terminalShakeFrames 0.3s ease'
         }
     }
 


### PR DESCRIPTION
## Problem
Fixes #11303. With the terminal bell set to **Visual**, the shake animation stops firing after a few rapid bells. Once a shake is mid-flight, subsequent BELs no longer produce any visible shake.
## Cause
`visualBell()` cleared the animation (`animation = 'none'`) and restored it inside a zero-delay `setTimeout`. When bells arrive while a previous shake is still playing, the clear and the restore land in the same paint frame, so the browser never registers a change and skips the restart.
## Fix
Force a synchronous reflow (`void this.element.offsetWidth`) between clearing and reassigning the animation, so each bell reliably retriggers the shake.
## Testing
Reproduced the animation-restart mechanism in a headless browser: firing 10 bells at 60 ms intervals (each landing mid-shake), the old code restarted the animation only 2/10 times; the fix restarts 10/10.