### PR TITLE
fix(ssh): prevent SFTP path navigation freeze

### DIFF
--- a/tabby-ssh/src/components/sftpPanel.component.ts
+++ b/tabby-ssh/src/components/sftpPanel.component.ts
@@ -61,12 +61,16 @@ export class SFTPPanelComponent {
 
         let p = newPath
         this.pathSegments = []
-        while (p !== '/') {
+        while (p !== '/' && p !== '.') {
             this.pathSegments.unshift({
                 name: path.basename(p),
                 path: p,
             })
-            p = path.dirname(p)
+            const parent = path.dirname(p)
+            if (parent === p) {
+                break
+            }
+            p = parent
         }
 
         this.fileList = null


### PR DESCRIPTION
## Summary

- stop SFTP breadcrumb generation when a relative path reaches `.`
- guard against fixed-point parent paths so invalid input cannot lock the renderer

## Root cause

The breadcrumb loop assumed every SFTP path was absolute. For `~`, `path.dirname()` reaches `.` and then keeps returning `.`, causing an infinite synchronous loop that freezes the UI.

Closes #11360

## Validation

- exercised path-segment regression cases for `~`, relative paths, absolute paths, `/`, and `.`
- transpiled the updated TypeScript component with esbuild
- ran `git diff --check`
