### PR TITLE
fix(terminal): fix Clear terminal hotkey action in PowerShell and Clink

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -257,7 +257,18 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     this.frontend?.selectAll()
                     break
                 case 'clear':
-                    this.forEachFocusedTerminalPane(tab => tab.frontend?.clear())
+                    this.forEachFocusedTerminalPane(tab => {
+                        const tabProfile = tab.profile as any
+                        const shellType: string = tabProfile.options?.shellType ?? ''
+                        const shellArgs: string[] = tabProfile.options?.args ?? []
+                        if (this.hostApp.platform === Platform.Windows && (shellType === 'powershell' || shellArgs.some(arg => arg.includes('clink')))) {
+                            // Windows PowerShell and cmd(Clink): send Ctrl+L to PTY (natively clears)
+                            tab.session?.write(Buffer.from('\x0c'))
+                        } else {
+                            // Windows cmd(stock) and macOS/Linux: clear xterm buffer only
+                            tab.frontend?.clear()
+                        }
+                    })
                     break
                 case 'zoom-in':
                     this.forEachFocusedTerminalPane(tab => tab.zoomIn())

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -258,7 +258,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     break
                 case 'clear':
                     this.forEachFocusedTerminalPane(tab => {
-                        const tabProfile = tab.profile as any
+                        const tabProfile = tab.profile
                         const shellType: string = tabProfile.options?.shellType ?? ''
                         const shellArgs: string[] = tabProfile.options?.args ?? []
                         if (this.hostApp.platform === Platform.Windows && (shellType === 'powershell' || shellArgs.some(arg => arg.includes('clink')))) {


### PR DESCRIPTION
#11403 

On Windows PowerShell (and cmd with Clink), the Clear terminal hotkey now sends Ctrl+L to the PTY instead of calling xterm.clear().
Other terminals continue to use xterm.clear().