### PR TITLE
ui polish: themed controls, animations, and small fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
 
     - name: Install deps
       run: |
-        sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+        sudo apt-get update || true
+        sudo apt-get install -y libfontconfig1-dev
         npm i -g yarn
         cd app
         yarn
@@ -178,7 +179,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get install libfontconfig1-dev libarchive-tools zsh crossbuild-essential-${{matrix.arch}}
 
     - name: Setup tar to run as root
@@ -195,7 +196,8 @@ jobs:
 
     - name: Setup crossbuild sysroot
       run: |
-        sudo apt-get update -y && sudo apt-get install debootstrap qemu-user-static binfmt-support -y
+        sudo apt-get update -y || true
+        sudo apt-get install debootstrap qemu-user-static binfmt-support -y
         sudo qemu-debootstrap --include=libfontconfig1-dev,libsecret-1-dev,libnss3,libatk1.0-0,libatk-bridge2.0-0,libgdk-pixbuf2.0-0,libgtk-3-0,libgbm1 --variant=buildd --exclude=snapd --components=main,restricted,universe,multiverse --extractor=dpkg-deb --arch ${{matrix.arch}} bionic /${{matrix.build-arch}}-sysroot/ http://ports.ubuntu.com/ubuntu-ports/
         sudo find /${{matrix.build-arch}}-sysroot -type l -lname '/*' -exec sh -c 'file="$0"; dir=$(dirname "$file"); target=$(readlink "$0"); prefix=$(dirname "$dir" | sed 's@[^/]*@\.\.@g'); newtarget="$prefix$target"; ln -snf $newtarget $file' {} \; ;
       if: matrix.build-arch == 'arm' && steps.dl-cached-sysroot.outputs.cache-hit != 'true'

--- a/app/lib/index.ts
+++ b/app/lib/index.ts
@@ -8,6 +8,9 @@ import 'dotenv/config'
 process.env.TABBY_PLUGINS ??= ''
 process.env.TABBY_CONFIG_DIRECTORY ??= app.getPath('userData')
 
+// CSS scroll-behavior only covers programmatic scrolls; this covers the wheel
+app.commandLine.appendSwitch('enable-smooth-scrolling')
+
 
 import 'v8-compile-cache'
 import 'source-map-support/register'

--- a/app/lib/pty.ts
+++ b/app/lib/pty.ts
@@ -147,6 +147,14 @@ export class PTYManager {
             this.ptys[id] = new PTY(id, app, ...options)
         })
 
+        // async variant — spawning a ConPTY takes tens of ms and the sendSync
+        // channel above blocks the renderer (and any UI animation) for all of it
+        ipcMain.handle('pty:spawn', (_event, ...options) => {
+            const id = uuidv4().toString()
+            this.ptys[id] = new PTY(id, app, ...options)
+            return id
+        })
+
         ipcMain.on('pty:exists', (event, id) => {
             event.returnValue = this.ptys[id] && !this.ptys[id].exited
         })

--- a/app/src/toastr.scss
+++ b/app/src/toastr.scss
@@ -5,7 +5,7 @@
   padding: 20px 0 50px;
 
   .toast {
-    box-shadow: 0 1px 0 rgba(0,0,0,.25);
+    box-shadow: 0 .5rem 1.5rem rgba(0,0,0,.35);
     padding: 7px 12px;
     background-image: none;
     display: block !important;
@@ -14,15 +14,22 @@
     flex-basis: auto;
     border-radius: 0.5rem;
     font-size: 0.75rem;
+    background-color: var(--theme-bg-less, #333);
+    color: var(--theme-fg, #eee) !important;
 
     &.toast-error {
-      background-color: #BD362F;
-      color: white !important;
+      background-color: var(--theme-danger, #BD362F);
+      color: var(--theme-danger-fg, white) !important;
+    }
+
+    &.toast-warning {
+      background-color: var(--theme-warning, #f0ad4e);
+      color: var(--theme-warning-fg, black) !important;
     }
 
     &.toast-info {
-      background-color: #555;
-      color: #eee !important;
+      background-color: var(--theme-bg-less-2, #555);
+      color: var(--theme-fg-less-2, #eee) !important;
     }
   }
 }

--- a/tabby-core/src/api/platform.ts
+++ b/tabby-core/src/api/platform.ts
@@ -49,6 +49,37 @@ export abstract class FileTransfer {
         return this.cancelled
     }
 
+    isFailed (): boolean {
+        return this.error !== null
+    }
+
+    getError (): string|null {
+        return this.error
+    }
+
+    markFailed (message: string): void {
+        this.error = message
+        this.close()
+    }
+
+    /** Registers a callback that restarts this transfer from scratch,
+     * resolving true once a replacement transfer exists */
+    setRetryHandler (fn: () => Promise<boolean>): void {
+        this.retryHandler = fn
+    }
+
+    canRetry (): boolean {
+        return !!this.retryHandler && (this.isFailed() || this.isCancelled())
+    }
+
+    async retry (): Promise<boolean> {
+        try {
+            return await this.retryHandler?.() ?? false
+        } catch {
+            return false
+        }
+    }
+
     cancel (): void {
         this.cancelled = true
         this.close()
@@ -64,6 +95,11 @@ export abstract class FileTransfer {
 
     setCompleted (completed: boolean): void {
         this.completed = completed
+        if (completed) {
+            // a done transfer can't be retried; don't pin the handler's closure
+            // (it captures the panel and session) for the lifetime of the list
+            this.retryHandler = null
+        }
     }
 
     protected increaseProgress (bytes: number): void {
@@ -71,7 +107,10 @@ export abstract class FileTransfer {
             return
         }
         this.completedBytes += bytes
-        this.lastChunkSpeed = bytes * 1000 / (Date.now() - this.lastChunkStartTime)
+        // concurrent children can report within the same millisecond — never
+        // divide by zero
+        const elapsed = Math.max(1, Date.now() - this.lastChunkStartTime)
+        this.lastChunkSpeed = bytes * 1000 / elapsed
         this.lastChunkStartTime = Date.now()
     }
 
@@ -80,8 +119,10 @@ export abstract class FileTransfer {
     private lastChunkStartTime = Date.now()
     private lastChunkSpeed = 0
     private cancelled = false
-    private completed = false
+    protected completed = false
     private status = ''
+    private error: string|null = null
+    private retryHandler: (() => Promise<boolean>)|null = null
 }
 
 export abstract class FileDownload extends FileTransfer {
@@ -91,6 +132,27 @@ export abstract class FileDownload extends FileTransfer {
 export abstract class DirectoryDownload extends FileTransfer {
     abstract createDirectory (relativePath: string): Promise<void>
     abstract createFile (relativePath: string, mode: number, size: number): Promise<FileDownload>
+
+    // the byte heuristic lies while the total size is still being calculated
+    isComplete (): boolean {
+        return this.completed
+    }
+
+    /** True once the recursive size scan finished and getSize() is meaningful */
+    isSizeCalculated (): boolean {
+        return this.sizeCalculated
+    }
+
+    setSizeCalculated (): void {
+        this.sizeCalculated = true
+    }
+
+    private sizeCalculated = false
+
+    /** Currently transferring files, for progress display */
+    getChildren (): FileTransfer[] {
+        return []
+    }
 }
 
 export abstract class FileUpload extends FileTransfer {

--- a/tabby-core/src/components/appRoot.component.pug
+++ b/tabby-core/src/components/appRoot.component.pug
@@ -74,8 +74,11 @@ title-bar(
                         (transfersChange)='onTransfersChange()'
                     )
 
+            //- .persistent reserves room for the window controls; skip it when the
+            //- window-controls-spacer below already does (it would double the reservation
+            //- and needlessly crush the tabs at narrow window widths)
             .btn-space.background(
-                [class.persistent]='config.store.appearance.frame == "thin"',
+                [class.persistent]='config.store.appearance.frame == "thin" && !(hostApp.platform == Platform.Windows && config.store.appearance.tabsLocation == "top")',
                 [class.drag]='config.store.appearance.frame == "thin" \
                 && ((config.store.appearance.tabsLocation !== "left" && config.store.appearance.tabsLocation !== "right") || hostApp.platform !== Platform.macOS)'
             )

--- a/tabby-core/src/components/appRoot.component.pug
+++ b/tabby-core/src/components/appRoot.component.pug
@@ -23,7 +23,7 @@ title-bar(
         .tab-bar(
             *ngIf='!hostWindow.isFullscreen || config.store.appearance.tabsInFullscreen',
             [class.tab-bar-no-controls-overlay]='hostApp.platform == Platform.macOS',
-            (dblclick)='!isTitleBarNeeded() && toggleMaximize()'
+            (dblclick)='onTabBarDblClick($event)'
         )
             .inset.background(*ngIf='hostApp.platform == Platform.macOS \
             && !hostWindow.isFullscreen \

--- a/tabby-core/src/components/appRoot.component.scss
+++ b/tabby-core/src/components/appRoot.component.scss
@@ -110,7 +110,7 @@ $tab-border-radius: 4px;
 
         text-transform: uppercase;
         font-weight: bold;
-        color: #aaa;
+        color: var(--theme-fg-more, #aaa);
         border: none;
         border-radius: 0;
 
@@ -202,12 +202,12 @@ hotkey-hint {
 ::ng-deep .btn-tab-bar + .dropdown-menu svg {
     width: calc(22px * var(--spaciness));
     height: calc(16px * var(--spaciness));
-    fill: white;
+    fill: var(--theme-fg, white);
     fill-opacity: 0.75;
 }
 
 ::ng-deep .btn-update svg {
-    fill: cyan;
+    fill: var(--theme-info, cyan);
 }
 
 ::ng-deep .broadcast-status-warning {

--- a/tabby-core/src/components/appRoot.component.ts
+++ b/tabby-core/src/components/appRoot.component.ts
@@ -70,6 +70,7 @@ export class AppRootComponent {
     @HostBinding('class.platform-darwin') platformClassMacOS = process.platform === 'darwin'
     @HostBinding('class.platform-linux') platformClassLinux = process.platform === 'linux'
     @HostBinding('class.no-tabs') noTabs = true
+    @HostBinding('class.window-blurred') windowBlurred = false
     @ViewChildren(TabBodyComponent) tabBodies: TabBodyComponent[]
     @ViewChild('activeTransfersDropdown') activeTransfersDropdown: NgbDropdown
     unsortedTabs: BaseTabComponent[] = []
@@ -216,6 +217,16 @@ export class AppRootComponent {
     @HostListener('drop')
     onDrop () {
         return false
+    }
+
+    @HostListener('window:blur')
+    onWindowBlur () {
+        this.windowBlurred = true
+    }
+
+    @HostListener('window:focus')
+    onWindowFocus () {
+        this.windowBlurred = false
     }
 
     hasVerticalTabs () {

--- a/tabby-core/src/components/appRoot.component.ts
+++ b/tabby-core/src/components/appRoot.component.ts
@@ -271,6 +271,17 @@ export class AppRootComponent {
         this.hostWindow.toggleMaximize()
     }
 
+    onTabBarDblClick (event: MouseEvent): void {
+        // titlebar-style maximize only for double-clicks on EMPTY bar space —
+        // clicks on tabs, buttons and dropdowns bubble up here too
+        const target = event.target as HTMLElement
+        const emptySpace = target.classList.contains('tab-bar')
+            || target.closest('.tab-bar > .btn-space, .tab-bar > .window-controls-spacer, .tab-bar > .inset')
+        if (emptySpace && !this.isTitleBarNeeded()) {
+            this.toggleMaximize()
+        }
+    }
+
     protected isTitleBarNeeded (): boolean {
         return (
             this.config.store.appearance.frame === 'full'

--- a/tabby-core/src/components/appRoot.component.ts
+++ b/tabby-core/src/components/appRoot.component.ts
@@ -31,7 +31,7 @@ function makeTabAnimation (dimension: string, size: number) {
                 'flex-basis': '1px',
                 [dimension]: '1px',
             }),
-            animate('250ms ease-out', style({
+            animate('150ms cubic-bezier(.2, .7, .3, 1)', style({
                 'flex-basis': '{{size}}',
                 [dimension]: '{{size}}',
             })),

--- a/tabby-core/src/components/profileTree.component.scss
+++ b/tabby-core/src/components/profileTree.component.scss
@@ -63,6 +63,7 @@ input {
                 background-color: var(--theme-bg-more-2);
                 border-radius: .2rem;
                 padding: 0 calc(.34rem * calc(var(--spaciness) * var(--spaciness)));
+                transition: background-color .12s ease-out, color .12s ease-out;
                 &:hover {
                     background-color: var(--theme-primary);
                     color: var(--theme-secondary);

--- a/tabby-core/src/components/profileTree.component.ts
+++ b/tabby-core/src/components/profileTree.component.ts
@@ -77,7 +77,7 @@ export class ProfileTreeComponent extends BaseComponent {
         groups.sort((a, b) => (a.id === 'built-in' || !a.editable ? 1 : 0) - (b.id === 'built-in' || !b.editable ? 1 : 0))
         groups.sort((a, b) => (a.id === 'ungrouped' ? 0 : 1) - (b.id === 'ungrouped' ? 0 : 1))
         this.profileGroups = groups.map(g => ProfileTreeComponent.intoPartialCollapsableProfileGroup(g, profileGroupCollapsed[g.id] ?? false))
-        this.rootGroups = this.profilesService.buildGroupTree(this.profileGroups)
+        this.rootGroups = ProfileTreeComponent.pruneEmptyGroups(this.profilesService.buildGroupTree(this.profileGroups))
     }
 
     private async editProfile (profile: PartialProfile<Profile>): Promise<void> {
@@ -204,7 +204,7 @@ export class ProfileTreeComponent extends BaseComponent {
             const q = this.filter.trim().toLowerCase()
 
             if (q.length === 0) {
-                this.rootGroups = this.profilesService.buildGroupTree(this.profileGroups)
+                this.rootGroups = ProfileTreeComponent.pruneEmptyGroups(this.profilesService.buildGroupTree(this.profileGroups))
                 return
             }
 
@@ -275,6 +275,17 @@ export class ProfileTreeComponent extends BaseComponent {
         const profileGroupCollapsed = JSON.parse(window.localStorage.profileGroupCollapsed ?? '{}')
         profileGroupCollapsed[group.id] = group.collapsed
         window.localStorage.profileGroupCollapsed = JSON.stringify(profileGroupCollapsed)
+    }
+
+    // Hide groups with no profiles and no non-empty subgroups; the sidebar is for
+    // launching, so empty folders are just noise (settings still shows them).
+    private static pruneEmptyGroups <T extends { profiles?: any[], children?: T[] }> (groups: T[]): T[] {
+        return groups.filter(group => {
+            if (group.children) {
+                group.children = ProfileTreeComponent.pruneEmptyGroups(group.children)
+            }
+            return !!group.profiles?.length || !!group.children?.length
+        })
     }
 
     private static intoPartialCollapsableProfileGroup (group: PartialProfileGroup<ProfileGroup>, collapsed: boolean): PartialProfileGroup<CollapsableProfileGroup> {

--- a/tabby-core/src/components/selectDropdown.component.pug
+++ b/tabby-core/src/components/selectDropdown.component.pug
@@ -1,0 +1,25 @@
+div.select-dropdown(ngbDropdown, #dropdown='ngbDropdown')
+    button.form-control.select-dropdown-toggle(
+        type='button',
+        ngbDropdownToggle,
+        [disabled]='disabled',
+        role='combobox',
+        aria-haspopup='listbox',
+        [attr.aria-expanded]='dropdown.isOpen()',
+        [attr.aria-label]='selectedName || placeholder'
+    )
+        span.select-dropdown-value([class.text-muted]='!selectedName') {{selectedName || placeholder}}
+        i.fas.fa-chevron-down.select-dropdown-caret([class.open]='dropdown.isOpen()')
+    .dropdown-menu.select-dropdown-menu(ngbDropdownMenu, role='listbox')
+        button.dropdown-item.d-flex.align-items-center(
+            type='button',
+            *ngFor='let option of options',
+            ngbDropdownItem,
+            role='option',
+            [attr.aria-selected]='option.value === value',
+            [class.active]='option.value === value',
+            [disabled]='option.disabled',
+            (click)='selectOption(option)'
+        )
+            span.flex-grow-1.no-wrap {{option.name}}
+            i.fas.fa-check.ms-2.select-dropdown-check(*ngIf='option.value === value')

--- a/tabby-core/src/components/selectDropdown.component.pug
+++ b/tabby-core/src/components/selectDropdown.component.pug
@@ -11,15 +11,17 @@ div.select-dropdown(ngbDropdown, #dropdown='ngbDropdown')
         span.select-dropdown-value([class.text-muted]='!selectedName') {{selectedName || placeholder}}
         i.fas.fa-chevron-down.select-dropdown-caret([class.open]='dropdown.isOpen()')
     .dropdown-menu.select-dropdown-menu(ngbDropdownMenu, role='listbox')
-        button.dropdown-item.d-flex.align-items-center(
-            type='button',
-            *ngFor='let option of options',
-            ngbDropdownItem,
-            role='option',
-            [attr.aria-selected]='option.value === value',
-            [class.active]='option.value === value',
-            [disabled]='option.disabled',
-            (click)='selectOption(option)'
-        )
-            span.flex-grow-1.no-wrap {{option.name}}
-            i.fas.fa-check.ms-2.select-dropdown-check(*ngIf='option.value === value')
+        .select-dropdown-group(*ngFor='let group of optionGroups; let first = first', [class.select-dropdown-group-separated]='!first')
+            .select-dropdown-group-label(*ngIf='group.label', role='presentation') {{group.label}}
+            button.dropdown-item.d-flex.align-items-center(
+                type='button',
+                *ngFor='let option of group.options',
+                ngbDropdownItem,
+                role='option',
+                [attr.aria-selected]='option.value === value',
+                [class.active]='option.value === value',
+                [disabled]='option.disabled',
+                (click)='selectOption(option)'
+            )
+                span.flex-grow-1.no-wrap {{option.name}}
+                i.fas.fa-check.ms-2.select-dropdown-check(*ngIf='option.value === value')

--- a/tabby-core/src/components/selectDropdown.component.scss
+++ b/tabby-core/src/components/selectDropdown.component.scss
@@ -49,6 +49,23 @@
     max-height: 50vh;
     overflow-y: auto;
 
+    .select-dropdown-group-label {
+        padding: .5rem 1rem .2rem;
+        font-size: .68rem;
+        font-weight: 700;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+        color: var(--theme-fg-less, #888);
+        user-select: none;
+        pointer-events: none;
+    }
+
+    .select-dropdown-group-separated {
+        border-top: 1px solid var(--theme-bg-more-2, rgba(255, 255, 255, .1));
+        margin-top: .15rem;
+        padding-top: .15rem;
+    }
+
     .select-dropdown-check {
         flex: none;
         font-size: .8em;

--- a/tabby-core/src/components/selectDropdown.component.scss
+++ b/tabby-core/src/components/selectDropdown.component.scss
@@ -1,0 +1,57 @@
+:host {
+    display: block;
+}
+
+:host(.disabled) {
+    pointer-events: none;
+    opacity: .65;
+}
+
+.select-dropdown-toggle {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+
+    // ng-bootstrap's dropdownToggle adds a .dropdown-toggle caret; we draw our own.
+    &::after {
+        display: none !important;
+    }
+
+    .select-dropdown-value {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .select-dropdown-caret {
+        flex: none;
+        margin-left: .5rem;
+        font-size: .7em;
+        opacity: .55;
+        transition: transform .15s ease-out;
+
+        &.open {
+            transform: rotate(180deg);
+        }
+    }
+}
+
+.select-dropdown {
+    display: block;
+}
+
+.select-dropdown-menu {
+    width: 100%;
+    min-width: max-content;
+    max-height: 50vh;
+    overflow-y: auto;
+
+    .select-dropdown-check {
+        flex: none;
+        font-size: .8em;
+        opacity: .8;
+    }
+}

--- a/tabby-core/src/components/selectDropdown.component.ts
+++ b/tabby-core/src/components/selectDropdown.component.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { Component, Input, HostBinding } from '@angular/core'
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
+
+export interface SelectDropdownOption {
+    value: any
+    name: string
+    disabled?: boolean
+}
+
+/**
+ * Themed drop-in replacement for a native `<select>` — binds with `[(ngModel)]`
+ * and renders the list as an ng-bootstrap dropdown, so the popup follows the app
+ * theme instead of being OS-rendered.
+ * @hidden
+ */
+@Component({
+    selector: 'select-dropdown',
+    templateUrl: './selectDropdown.component.pug',
+    styleUrls: ['./selectDropdown.component.scss'],
+    providers: [
+        { provide: NG_VALUE_ACCESSOR, useExisting: SelectDropdownComponent, multi: true },
+    ],
+})
+export class SelectDropdownComponent implements ControlValueAccessor {
+    @Input() options: SelectDropdownOption[] = []
+    @Input() placeholder = ''
+    @HostBinding('class.disabled') @Input() disabled = false
+    value: any
+    private changed = new Array<(value: any) => void>()
+    private touched = new Array<() => void>()
+
+    get selectedName (): string {
+        const found = this.options.find(o => o.value === this.value)
+        return found ? found.name : this.placeholder
+    }
+
+    selectOption (option: SelectDropdownOption): void {
+        if (option.disabled) {
+            return
+        }
+        this.value = option.value
+        this.changed.forEach(fn => fn(this.value))
+        this.touched.forEach(fn => fn())
+    }
+
+    writeValue (value: any): void {
+        this.value = value ?? null
+    }
+
+    registerOnChange (fn: any): void {
+        this.changed.push(fn)
+    }
+
+    registerOnTouched (fn: any): void {
+        this.touched.push(fn)
+    }
+
+    setDisabledState (isDisabled: boolean): void {
+        this.disabled = isDisabled
+    }
+}

--- a/tabby-core/src/components/selectDropdown.component.ts
+++ b/tabby-core/src/components/selectDropdown.component.ts
@@ -6,6 +6,13 @@ export interface SelectDropdownOption {
     value: any
     name: string
     disabled?: boolean
+    /** Options sharing a group render under a common header, like a native `<optgroup>` */
+    group?: string
+}
+
+interface SelectDropdownOptionGroup {
+    label: string|null
+    options: SelectDropdownOption[]
 }
 
 /**
@@ -23,16 +30,48 @@ export interface SelectDropdownOption {
     ],
 })
 export class SelectDropdownComponent implements ControlValueAccessor {
-    @Input() options: SelectDropdownOption[] = []
     @Input() placeholder = ''
     @HostBinding('class.disabled') @Input() disabled = false
     value: any
+    optionGroups: SelectDropdownOptionGroup[] = []
+    private _options: SelectDropdownOption[] = []
     private changed = new Array<(value: any) => void>()
     private touched = new Array<() => void>()
 
+    @Input()
+    set options (value: SelectDropdownOption[]) {
+        this._options = value
+        this.rebuildOptionGroups()
+    }
+
+    get options (): SelectDropdownOption[] {
+        return this._options
+    }
+
     get selectedName (): string {
-        const found = this.options.find(o => o.value === this.value)
+        const found = this._options.find(o => o.value === this.value)
         return found ? found.name : this.placeholder
+    }
+
+    private rebuildOptionGroups (): void {
+        if (!this._options.some(o => o.group)) {
+            this.optionGroups = this._options.length
+                ? [{ label: null, options: [...this._options] }]
+                : []
+            return
+        }
+
+        const groups: SelectDropdownOptionGroup[] = []
+        for (const option of this._options) {
+            const label = option.group ?? null
+            const last = groups.length > 0 ? groups[groups.length - 1] : null
+            if (last && last.label === label) {
+                last.options.push(option)
+            } else {
+                groups.push({ label, options: [option] })
+            }
+        }
+        this.optionGroups = groups
     }
 
     selectOption (option: SelectDropdownOption): void {

--- a/tabby-core/src/components/selectorModal.component.pug
+++ b/tabby-core/src/components/selectorModal.component.pug
@@ -7,7 +7,7 @@
         (ngModelChange)='onFilterChange()'
     )
 
-    .list-group.list-group-light(*ngIf='filteredOptions.length')
+    .list-group.list-group-light(*ngIf='filteredOptions.length', animatedNavIndicator='.list-group-item.active')
         ng-container(*ngFor='let option of filteredOptions; let i = index')
             label.group-header(
                 *ngIf='hasGroups && option.group !== filteredOptions[i - 1]?.group'

--- a/tabby-core/src/components/splitTabPaneLabel.component.scss
+++ b/tabby-core/src/components/splitTabPaneLabel.component.scss
@@ -1,6 +1,6 @@
 :host {
     position: absolute;
-    background: rgba(0, 0, 0, .5);
+    background: var(--overlay-dim, rgba(0, 0, 0, .5));
     display: flex;
     align-items: center;
     justify-content: center;

--- a/tabby-core/src/components/tabHeader.component.ts
+++ b/tabby-core/src/components/tabHeader.component.ts
@@ -99,13 +99,16 @@ export class TabHeaderComponent extends BaseComponent {
     }
 
     @HostListener('mousedown', ['$event']) async onMouseDown ($event: MouseEvent) {
-        if ($event.which === 2) {
+        if ($event.button === 1) {
+            // suppress Chromium's middle-click autoscroll
             $event.preventDefault()
         }
     }
 
-    @HostListener('mouseup', ['$event']) async onMouseUp ($event: MouseEvent) {
-        if ($event.which === 2) {
+    // auxclick pairs press+release like click; a bare mouseup made this unreliable
+    @HostListener('auxclick', ['$event']) async onAuxClick ($event: MouseEvent) {
+        if ($event.button === 1) {
+            $event.preventDefault()
             this.app.closeTab(this.tab, true)
         }
     }

--- a/tabby-core/src/components/toggle.component.scss
+++ b/tabby-core/src/components/toggle.component.scss
@@ -1,24 +1,12 @@
 :host {
     flex: none;
-    $toggle-size: 18px;
-    $height: 30px;
-    $padding: 2px;
     display: inline-flex;
-    border-radius: 3px;
-    line-height: $height;
-    height: $height;
-    transition: 0.25s opacity;
     align-items: center;
-    padding-right: 10px;
-    padding-left: 10px;
-    margin-left: -10px;
-
-    .form-check {
-        margin: 0;
-    }
+    height: 30px;
 
     &.disabled {
         opacity: 0.5;
+        pointer-events: none;
     }
 
     * {
@@ -27,5 +15,91 @@
 
     label {
         display: none;
+    }
+}
+
+// Custom switch: the input is the track (appearance: none); the knob is the
+// wrapper's ::after, since inputs can't carry pseudo-elements.
+.form-check.form-switch {
+    position: relative;
+    margin: 0;
+    padding: 0;
+    width: 40px;
+    height: 22px;
+
+    input.form-check-input {
+        appearance: none;
+        -webkit-appearance: none;
+        float: none;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        border-radius: 22px;
+        background-image: none !important;
+        background-color: var(--theme-bg-more-2);
+        border: 1px solid var(--theme-bg-less);
+        transition: background-color .18s ease-out, border-color .18s ease-out;
+
+        &:checked {
+            background-color: var(--theme-primary);
+            border-color: var(--theme-primary-more);
+        }
+    }
+
+    // knob
+    &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 3px;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: var(--theme-fg-more);
+        translate: 0 -50%;
+        pointer-events: none;
+        transition:
+            translate .18s cubic-bezier(.34, 1.3, .5, 1),
+            background-color .18s ease-out;
+    }
+
+    &:has(input:checked)::after {
+        translate: 18px -50%;
+        background: var(--theme-primary-fg);
+    }
+
+    &:hover input.form-check-input {
+        border-color: var(--theme-fg-more-2);
+    }
+}
+
+:host-context(body.no-animations) .form-check.form-switch {
+    input.form-check-input,
+    &::after {
+        transition: none;
+    }
+}
+
+// Forced colors would make the knob and track indistinguishable
+@media (forced-colors: active) {
+    .form-check.form-switch {
+        input.form-check-input {
+            forced-color-adjust: none;
+            background-color: ButtonFace;
+            border: 1px solid ButtonText;
+
+            &:checked {
+                background-color: Highlight;
+            }
+        }
+
+        &::after {
+            forced-color-adjust: none;
+            background: ButtonText;
+        }
+
+        &:has(input:checked)::after {
+            background: HighlightText;
+        }
     }
 }

--- a/tabby-core/src/components/toggle.component.ts
+++ b/tabby-core/src/components/toggle.component.ts
@@ -8,7 +8,7 @@ import { CheckboxComponent } from './checkbox.component'
     template: `
     <div class="form-check form-switch">
       <input type="checkbox" class="form-check-input" [(ngModel)]='model'>
-      <label class="cform-check-label"></label>
+      <label class="form-check-label"></label>
     </div>
     `,
     styleUrls: ['./toggle.component.scss'],

--- a/tabby-core/src/components/transfersMenu.component.pug
+++ b/tabby-core/src/components/transfersMenu.component.pug
@@ -7,12 +7,25 @@
     .main
         label.no-wrap([ngbTooltip]='transfer.getName()')
             | {{transfer.getName()}}
-            span.ms-2.text-muted(*ngIf='transfer.getStatus()') ({{transfer.getStatus()}})
-        ngb-progressbar([type]='transfer.isComplete() ? "success" : transfer.isCancelled() ? "danger" : "info"', [value]='getProgress(transfer)')
+            span.ms-2.text-muted(*ngIf='getActiveChild(transfer) as child') {{child.getName()}} — {{getProgress(child)}}%
+            span.ms-2.text-muted(*ngIf='!getActiveChild(transfer) && transfer.getStatus() && !transfer.isFailed()') ({{transfer.getStatus()}})
+        ngb-progressbar([type]='getBarType(transfer)', [value]='isSizeUnknown(transfer) ? 100 : getProgress(transfer)', [striped]='isSizeUnknown(transfer)', [animated]='isSizeUnknown(transfer)')
         .metadata
-            .size {{transfer.getSize()|filesize}}
-            .speed(*ngIf='transfer.getSpeed()') {{transfer.getSpeed()|filesize}}/s
+            .size(*ngIf='isSizeUnknown(transfer)')
+                | {{transfer.getCompletedBytes()|filesize}} / ≥{{transfer.getSize()|filesize}}&nbsp;
+                span(translate) (scanning)
+            .size(*ngIf='!isSizeUnknown(transfer)') {{transfer.getCompletedBytes()|filesize}} / {{transfer.getSize()|filesize}}
+            .percent(*ngIf='!isSizeUnknown(transfer)') {{getProgress(transfer)}}%
+            .state([class.text-danger]='transfer.isFailed() || transfer.isCancelled()') {{getStateLabel(transfer)}}
+            .speed(*ngIf='!transfer.isComplete() && !transfer.isFailed() && !transfer.isCancelled() && transfer.getSpeed()') {{transfer.getSpeed()|filesize}}/s
+        label.no-wrap.error.text-danger(*ngIf='transfer.isFailed()', [ngbTooltip]='transfer.getError()') {{transfer.getError()}}
 
+    button.btn.btn-link(
+        *ngIf='transfer.canRetry()',
+        [ngbTooltip]='retryLabel',
+        (click)='retryTransfer(transfer); $event.stopPropagation()'
+    )
+        i.fas.fa-redo
     button.btn.btn-link(
         *ngIf='!transfer.isComplete()',
         (click)='removeTransfer(transfer); $event.stopPropagation()'

--- a/tabby-core/src/components/transfersMenu.component.scss
+++ b/tabby-core/src/components/transfersMenu.component.scss
@@ -14,6 +14,7 @@
     align-items: center;
     padding: 5px 0 5px 25px;
     width: 100%;
+    cursor: pointer;
 
     .icon {
         padding: 4px 7px;

--- a/tabby-core/src/components/transfersMenu.component.scss
+++ b/tabby-core/src/components/transfersMenu.component.scss
@@ -1,5 +1,7 @@
 :host {
-    min-width: 300px;
+    // constant width: any content-driven resize makes Popper re-place (flip)
+    // the menu at narrow window widths as transfer paths change length
+    width: min(420px, 90vw);
     max-height: 80vh;
     overflow-y: auto;
 
@@ -44,9 +46,23 @@
         display: flex;
         align-items: center;
 
+        .percent {
+            margin-left: 8px;
+        }
+
+        .state {
+            margin-left: 8px;
+        }
+
         .speed {
             margin-left: auto;
         }
+    }
+
+    .error {
+        font-size: 10px;
+        margin: 0;
+        max-width: 100%;
     }
 
     > i {

--- a/tabby-core/src/components/transfersMenu.component.ts
+++ b/tabby-core/src/components/transfersMenu.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, HostBinding } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { ConfigService } from '../services/config.service'
-import { FileDownload, FileTransfer, PlatformService } from '../api/platform'
+import { DirectoryDownload, FileDownload, FileTransfer, PlatformService } from '../api/platform'
 
 /** @hidden */
 @Component({
@@ -12,6 +12,7 @@ import { FileDownload, FileTransfer, PlatformService } from '../api/platform'
 export class TransfersMenuComponent {
     @Input() transfers: FileTransfer[]
     @Output() transfersChange = new EventEmitter<FileTransfer[]>()
+    retryLabel: string
     @HostBinding('class.vibrant') get isVibrant (): boolean {
         return this.config.store.appearance.vibrancy
     }
@@ -20,14 +21,65 @@ export class TransfersMenuComponent {
         private config: ConfigService,
         private platform: PlatformService,
         private translate: TranslateService,
-    ) { }
+    ) {
+        this.retryLabel = translate.instant('Retry')
+    }
 
     isDownload (transfer: FileTransfer): boolean {
         return transfer instanceof FileDownload
     }
 
     getProgress (transfer: FileTransfer): number {
-        return Math.round(100 * transfer.getCompletedBytes() / transfer.getSize())
+        if (!transfer.getSize()) {
+            return 0
+        }
+        // the total can lag behind (e.g. a folder size still being calculated)
+        return Math.min(100, Math.round(100 * transfer.getCompletedBytes() / transfer.getSize()))
+    }
+
+    getChildren (transfer: FileTransfer): FileTransfer[] {
+        return transfer instanceof DirectoryDownload ? transfer.getChildren() : []
+    }
+
+    getActiveChild (transfer: FileTransfer): FileTransfer|null {
+        return this.getChildren(transfer).find(x => !x.isComplete()) ?? null
+    }
+
+    isSizeUnknown (transfer: FileTransfer): boolean {
+        return transfer instanceof DirectoryDownload
+            && !transfer.isSizeCalculated()
+            && !transfer.isComplete() && !transfer.isFailed() && !transfer.isCancelled()
+    }
+
+    getBarType (transfer: FileTransfer): string {
+        if (transfer.isFailed() || transfer.isCancelled()) {
+            return 'danger'
+        }
+        return transfer.isComplete() ? 'success' : 'info'
+    }
+
+    getStateLabel (transfer: FileTransfer): string {
+        if (transfer.isFailed()) {
+            return this.translate.instant('Failed')
+        }
+        if (transfer.isCancelled()) {
+            return this.translate.instant('Cancelled')
+        }
+        if (transfer.isComplete()) {
+            return this.translate.instant('Done')
+        }
+        return ''
+    }
+
+    async retryTransfer (transfer: FileTransfer): Promise<void> {
+        this.transfers = this.transfers.filter(x => x !== transfer)
+        this.transfersChange.emit(this.transfers)
+        if (!await transfer.retry()) {
+            // nothing replaced it (e.g. the re-prompt was dismissed) — put the
+            // old entry back so the retry affordance isn't lost
+            this.transfers = [...this.transfers, transfer]
+            this.transfersChange.emit(this.transfers)
+        }
     }
 
     showTransfer (transfer: FileTransfer): void {
@@ -38,7 +90,7 @@ export class TransfersMenuComponent {
     }
 
     removeTransfer (transfer: FileTransfer): void {
-        if (!transfer.isComplete()) {
+        if (!transfer.isComplete() && !transfer.isFailed()) {
             transfer.cancel()
         }
         this.transfers = this.transfers.filter(x => x !== transfer)

--- a/tabby-core/src/components/welcomeTab.component.pug
+++ b/tabby-core/src/components/welcomeTab.component.pug
@@ -9,12 +9,11 @@
     .form-line
         .header
             .title(translate) Language
-        select.form-control([(ngModel)]='config.store.language', (ngModelChange)='config.save()')
-            option([ngValue]='null', translate) Automatic
-            option(
-                [value]='lang.code',
-                *ngFor='let lang of allLanguages'
-            ) {{lang.name}}
+        select-dropdown(
+            [(ngModel)]='config.store.language',
+            [options]='languageOptions',
+            (ngModelChange)='config.save()'
+        )
 
     .form-line
         .header

--- a/tabby-core/src/components/welcomeTab.component.ts
+++ b/tabby-core/src/components/welcomeTab.component.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, Injector } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { BaseTabComponent } from './baseTab.component'
@@ -14,6 +15,7 @@ import { LocaleService } from '../services/locale.service'
 export class WelcomeTabComponent extends BaseTabComponent {
     enableGlobalHotkey = true
     allLanguages = LocaleService.allLanguages
+    languageOptions: { value: any, name: string }[] = []
 
     constructor (
         public config: ConfigService,
@@ -23,6 +25,10 @@ export class WelcomeTabComponent extends BaseTabComponent {
     ) {
         super(injector)
         this.setTitle(translate.instant('Welcome'))
+        this.languageOptions = [
+            { value: null, name: translate.instant(_('Automatic')) },
+            ...this.allLanguages.map(lang => ({ value: lang.code, name: lang.name })),
+        ]
     }
 
     async closeAndDisable () {

--- a/tabby-core/src/configDefaults.linux.yaml
+++ b/tabby-core/src/configDefaults.linux.yaml
@@ -3,6 +3,7 @@ hotkeys:
     - 'F11'
   close-tab:
     - 'Ctrl-Shift-W'
+    - 'Ctrl-W'
   reopen-tab:
     - 'Ctrl-Shift-Z'
   toggle-last-tab: []

--- a/tabby-core/src/configDefaults.windows.yaml
+++ b/tabby-core/src/configDefaults.windows.yaml
@@ -4,6 +4,7 @@ hotkeys:
     - 'Alt-Enter'
   close-tab:
     - 'Ctrl-Shift-W'
+    - 'Ctrl-W'
   reopen-tab:
     - 'Ctrl-Shift-Z'
   toggle-last-tab: []

--- a/tabby-core/src/directives/dropZone.directive.scss
+++ b/tabby-core/src/directives/dropZone.directive.scss
@@ -4,7 +4,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, .5);
+    background: var(--overlay-dim, rgba(0, 0, 0, .5));
     pointer-events: none;
     z-index: 1;
     display: flex;

--- a/tabby-core/src/directives/dropdownCloseAnimation.directive.ts
+++ b/tabby-core/src/directives/dropdownCloseAnimation.directive.ts
@@ -1,0 +1,65 @@
+import { Directive, OnInit } from '@angular/core'
+import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap'
+
+/**
+ * Animates every NgbDropdown on close. close() destroys the Popper instance,
+ * synchronously stripping the menu's positioning, so no CSS transition can ever
+ * play — instead the menu is pinned at its on-screen position and faded out here.
+ * @hidden
+ */
+@Directive({
+    selector: '[ngbDropdown]',
+})
+export class DropdownCloseAnimationDirective implements OnInit {
+    private closeAnimation: Animation|null = null
+
+    constructor (private dropdown: NgbDropdown) { }
+
+    ngOnInit (): void {
+        // reopening mid-fade must cancel it, or the fade would run over the fresh menu
+        const originalOpen = this.dropdown.open.bind(this.dropdown)
+        this.dropdown.open = () => {
+            this.closeAnimation?.cancel()
+            this.closeAnimation = null
+            originalOpen()
+        }
+
+        const originalClose = this.dropdown.close.bind(this.dropdown)
+        this.dropdown.close = () => {
+            const menu: HTMLElement|undefined = (this.dropdown as any)._menu?.nativeElement
+            if (!menu || !this.dropdown.isOpen() || document.body.classList.contains('no-animations')) {
+                originalClose()
+                return
+            }
+            const rect = menu.getBoundingClientRect()
+            originalClose()
+            menu.classList.add('dropdown-menu-closing')
+            // closed menus are display:none — force the menu visible for the fade
+            menu.style.display = 'block'
+            menu.style.position = 'fixed'
+            menu.style.top = `${rect.top}px`
+            menu.style.left = `${rect.left}px`
+            menu.style.width = `${rect.width}px`
+            menu.style.margin = '0'
+            let done = false
+            const cleanup = () => {
+                if (done) {
+                    return
+                }
+                done = true
+                menu.classList.remove('dropdown-menu-closing')
+                for (const prop of ['display', 'position', 'top', 'left', 'width', 'margin']) {
+                    menu.style.removeProperty(prop)
+                }
+            }
+            const animation = menu.animate([
+                { opacity: 1, scale: '1' },
+                { opacity: 0, scale: '0.97' },
+            ], { duration: 140, easing: 'ease-out' })
+            this.closeAnimation = animation
+            animation.onfinish = cleanup
+            animation.oncancel = cleanup
+            setTimeout(cleanup, 400)
+        }
+    }
+}

--- a/tabby-core/src/directives/navIndicator.directive.ts
+++ b/tabby-core/src/directives/navIndicator.directive.ts
@@ -1,0 +1,89 @@
+import { Directive, ElementRef, Input, AfterViewInit, OnDestroy } from '@angular/core'
+
+/**
+ * Sliding active-item indicator shared by the settings sidebar and the selector
+ * modal: a .nav-indicator surface is slid to the active item's box whenever the
+ * active class moves. Item changes and resizes re-align without animating.
+ * @hidden
+ */
+@Directive({
+    selector: '[animatedNavIndicator]',
+})
+export class NavIndicatorDirective implements AfterViewInit, OnDestroy {
+    @Input('animatedNavIndicator') activeSelector: string
+
+    private indicator?: HTMLElement
+    private observer?: MutationObserver
+    private resizeObserver?: ResizeObserver
+    private rect?: { top: number, left: number }
+
+    constructor (private el: ElementRef) { }
+
+    ngAfterViewInit (): void {
+        const host: HTMLElement = this.el.nativeElement
+        if (getComputedStyle(host).position === 'static') {
+            host.style.position = 'relative'
+        }
+        this.indicator = document.createElement('div')
+        this.indicator.className = 'nav-indicator'
+        host.insertBefore(this.indicator, host.firstChild)
+
+        this.observer = new MutationObserver(mutations => {
+            const isNavigation = mutations.some(m => m.type === 'attributes')
+            this.measure(isNavigation)
+        })
+        this.observer.observe(host, { attributes: true, attributeFilter: ['class'], subtree: true, childList: true })
+        this.resizeObserver = new ResizeObserver(() => this.measure(false))
+        this.resizeObserver.observe(host)
+        setTimeout(() => this.measure(false), 100)
+    }
+
+    private measure (animate: boolean): void {
+        const host: HTMLElement = this.el.nativeElement
+        const indicator = this.indicator
+        if (!indicator) {
+            return
+        }
+        const active = host.querySelector<HTMLElement>(this.activeSelector || '.active')
+        if (!active) {
+            indicator.style.opacity = '0'
+            this.rect = undefined
+            return
+        }
+
+        const target = {
+            top: active.offsetTop,
+            left: active.offsetLeft,
+            width: active.offsetWidth,
+            height: active.offsetHeight,
+        }
+        const previous = this.rect
+        this.rect = { top: target.top, left: target.left }
+
+        indicator.style.top = `${target.top}px`
+        indicator.style.left = `${target.left}px`
+        indicator.style.width = `${target.width}px`
+        indicator.style.height = `${target.height}px`
+        indicator.style.opacity = '1'
+
+        if (animate && previous && !document.body.classList.contains('no-animations')) {
+            const dx = previous.left - target.left
+            const dy = previous.top - target.top
+            if (dx || dy) {
+                indicator.animate([
+                    { transform: `translate(${dx}px, ${dy}px)` },
+                    { transform: 'none' },
+                ], {
+                    duration: 220,
+                    easing: 'cubic-bezier(.4, .85, .3, 1)',
+                })
+            }
+        }
+    }
+
+    ngOnDestroy (): void {
+        this.observer?.disconnect()
+        this.resizeObserver?.disconnect()
+        this.indicator?.remove()
+    }
+}

--- a/tabby-core/src/directives/segmentedToggle.directive.ts
+++ b/tabby-core/src/directives/segmentedToggle.directive.ts
@@ -1,0 +1,60 @@
+import { Directive, ElementRef, AfterViewInit, OnDestroy } from '@angular/core'
+
+/**
+ * Animates btn-check based .btn-groups (segmented toggles): a single surface —
+ * the group's ::before, positioned via the --segment-* variables — slides behind
+ * the checked segment instead of the checked background snapping between buttons.
+ * @hidden
+ */
+@Directive({
+    selector: '.btn-group',
+})
+export class SegmentedToggleIndicatorDirective implements AfterViewInit, OnDestroy {
+    private changeHandler = () => setTimeout(() => this.update())
+    private initialized = false
+
+    constructor (private el: ElementRef) { }
+
+    ngAfterViewInit (): void {
+        const host: HTMLElement = this.el.nativeElement
+        if (!host.querySelector(':scope > .btn-check')) {
+            return
+        }
+        host.classList.add('has-segment-indicator')
+        host.addEventListener('change', this.changeHandler)
+        // ngModel applies the initial checked state asynchronously
+        setTimeout(() => this.update(), 100)
+        setTimeout(() => this.update(), 500)
+    }
+
+    private update (): void {
+        const host: HTMLElement = this.el.nativeElement
+        const checked = host.querySelector<HTMLElement>(':scope > .btn-check:checked + .btn')
+        if (!checked) {
+            host.style.setProperty('--segment-opacity', '0')
+            this.initialized = false
+            return
+        }
+        const apply = () => {
+            host.style.setProperty('--segment-left', `${checked.offsetLeft}px`)
+            host.style.setProperty('--segment-top', `${checked.offsetTop}px`)
+            host.style.setProperty('--segment-width', `${checked.offsetWidth}px`)
+            host.style.setProperty('--segment-height', `${checked.offsetHeight}px`)
+            host.style.setProperty('--segment-opacity', '1')
+        }
+        if (!this.initialized) {
+            // first paint: place the indicator without animating it into position
+            host.classList.add('segment-indicator-init')
+            apply()
+            void host.offsetWidth
+            host.classList.remove('segment-indicator-init')
+            this.initialized = true
+        } else {
+            apply()
+        }
+    }
+
+    ngOnDestroy (): void {
+        this.el.nativeElement.removeEventListener('change', this.changeHandler)
+    }
+}

--- a/tabby-core/src/index.ts
+++ b/tabby-core/src/index.ts
@@ -16,6 +16,7 @@ import { TabBodyComponent } from './components/tabBody.component'
 import { PromptModalComponent } from './components/promptModal.component'
 import { SafeModeModalComponent } from './components/safeModeModal.component'
 import { StartPageComponent } from './components/startPage.component'
+import { SelectDropdownComponent } from './components/selectDropdown.component'
 import { TabHeaderComponent } from './components/tabHeader.component'
 import { TitleBarComponent } from './components/titleBar.component'
 import { ToggleComponent } from './components/toggle.component'
@@ -33,6 +34,9 @@ import { ProfileIconComponent } from './components/profileIcon.component'
 import { ProfileTreeComponent } from './components/profileTree.component'
 
 import { AutofocusDirective } from './directives/autofocus.directive'
+import { DropdownCloseAnimationDirective } from './directives/dropdownCloseAnimation.directive'
+import { SegmentedToggleIndicatorDirective } from './directives/segmentedToggle.directive'
+import { NavIndicatorDirective } from './directives/navIndicator.directive'
 import { AlwaysVisibleTypeaheadDirective } from './directives/alwaysVisibleTypeahead.directive'
 import { FastHtmlBindDirective } from './directives/fastHtmlBind.directive'
 import { DropZoneDirective } from './directives/dropZone.directive'
@@ -108,6 +112,7 @@ const PROVIDERS = [
     declarations: [
         AppRootComponent,
         CheckboxComponent,
+        SelectDropdownComponent,
         PromptModalComponent,
         StartPageComponent,
         TabBodyComponent,
@@ -118,6 +123,9 @@ const PROVIDERS = [
         RenameTabModalComponent,
         SafeModeModalComponent,
         AutofocusDirective,
+        DropdownCloseAnimationDirective,
+        SegmentedToggleIndicatorDirective,
+        NavIndicatorDirective,
         FastHtmlBindDirective,
         AlwaysVisibleTypeaheadDirective,
         SelectorModalComponent,
@@ -137,9 +145,13 @@ const PROVIDERS = [
     exports: [
         AppRootComponent,
         CheckboxComponent,
+        SelectDropdownComponent,
         ToggleComponent,
         PromptModalComponent,
         AutofocusDirective,
+        DropdownCloseAnimationDirective,
+        SegmentedToggleIndicatorDirective,
+        NavIndicatorDirective,
         DropZoneDirective,
         FastHtmlBindDirective,
         AlwaysVisibleTypeaheadDirective,

--- a/tabby-core/src/services/config.service.ts
+++ b/tabby-core/src/services/config.service.ts
@@ -160,6 +160,10 @@ export class ConfigService {
     private _store: any
     private defaults: any
     private servicesCache: Record<string, Function[]>|null = null // eslint-disable-line @typescript-eslint/ban-types
+    private bootStore: any = null
+    private lastStore: any = null
+    private restartDiffKeys = new Set<string>()
+    private restartForced = false
 
     get changed$ (): Observable<void> { return this.changed }
 
@@ -259,7 +263,32 @@ export class ConfigService {
     }
 
     requestRestart (): void {
-        this.restartRequested = true
+        // Records which config paths this change moved away from the booted values,
+        // so undoing the change clears the restart notice again.
+        if (this.bootStore && this._store) {
+            const current = JSON.parse(JSON.stringify(this._store))
+            const paths: string[][] = []
+            // diffing against the last-emitted state captures only this change's
+            // paths, so unrelated earlier edits can't keep the notice stuck
+            this.collectDiffPaths(this.lastStore ?? this.bootStore, current, [], paths)
+            for (const path of paths) {
+                this.restartDiffKeys.add(JSON.stringify(path))
+            }
+            // a zero-diff call is intentionally ignored: rapid change+undo within one
+            // debounce window lands here with the config already back to normal
+        } else {
+            this.restartForced = true
+        }
+        this.updateRestartRequested()
+    }
+
+    /**
+     * Requests a restart that no config change can undo (e.g. after a plugin
+     * install), keeping the notice sticky until the app restarts.
+     */
+    requestRestartForced (): void {
+        this.restartForced = true
+        this.updateRestartRequested()
     }
 
     /**
@@ -297,6 +326,9 @@ export class ConfigService {
 
     private async init () {
         await this.load()
+        // snapshot of the config the running app actually booted with
+        this.bootStore = JSON.parse(JSON.stringify(this._store))
+        this.lastStore = JSON.parse(JSON.stringify(this._store))
         this.ready.next(true)
         this.ready.complete()
 
@@ -308,7 +340,48 @@ export class ConfigService {
 
     private emitChange (): void {
         this.vault.setStore(this.store.vault)
+        this.updateRestartRequested()
+        if (this._store) {
+            this.lastStore = JSON.parse(JSON.stringify(this._store))
+        }
         this.changed.next()
+    }
+
+    private updateRestartRequested (): void {
+        if (this.restartForced) {
+            this.restartRequested = true
+            return
+        }
+        if (!this.bootStore || !this._store || !this.restartDiffKeys.size) {
+            return
+        }
+        const current = JSON.parse(JSON.stringify(this._store))
+        this.restartRequested = [...this.restartDiffKeys].some(key => {
+            const path = JSON.parse(key)
+            return !deepEqual(this.getAtPath(this.bootStore, path), this.getAtPath(current, path))
+        })
+    }
+
+    private collectDiffPaths (a: any, b: any, prefix: string[], out: string[][]): void {
+        const isPlainObject = x => x && typeof x === 'object' && !(x instanceof Array)
+        if (isPlainObject(a) && isPlainObject(b)) {
+            for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+                this.collectDiffPaths(a[key], b[key], [...prefix, key], out)
+            }
+        } else if (!deepEqual(a, b)) {
+            out.push(prefix)
+        }
+    }
+
+    private getAtPath (obj: any, path: string[]): any {
+        let current = obj
+        for (const key of path) {
+            if (current === null || current === undefined) {
+                return undefined
+            }
+            current = current[key]
+        }
+        return current
     }
 
     // eslint-disable-next-line max-statements

--- a/tabby-core/src/services/themes.service.ts
+++ b/tabby-core/src/services/themes.service.ts
@@ -110,6 +110,12 @@ export class ThemesService {
             vars['--theme-bg-more'] = backgroundMore
             vars['--theme-bg-more-2'] = more(backgroundMore, 0.25).string()
 
+            // Blurred-window tab bar tint: blend the bar's own color (--theme-bg-more-2)
+            // towards the opposite extreme, so the change stays visible on schemes where
+            // the multiplicative lighten/darken above is a no-op (e.g. pure black backgrounds)
+            const tabBarBg = more(backgroundMore, 0.25)
+            vars['--theme-tab-bar-blurred-bg'] = tabBarBg.mix(Color(isDark ? 'white' : 'black'), 0.12).string()
+
             contrastPairs.push(['--theme-bg', '--theme-fg'])
             contrastPairs.push(['--theme-bg-less', '--theme-fg-less'])
             contrastPairs.push(['--theme-bg-less-2', '--theme-fg-less-2'])

--- a/tabby-core/src/services/themes.service.ts
+++ b/tabby-core/src/services/themes.service.ts
@@ -169,6 +169,8 @@ export class ThemesService {
             document.documentElement.style.setProperty(key, value)
         }
 
+        // Deliberately not OR-ed with prefers-reduced-motion: the OS hint is often
+        // set system-wide while the user explicitly enables Tabby's animations.
         document.body.classList.toggle('no-animations', !this.getConfigStoreOrDefaults().accessibility.animations)
     }
 

--- a/tabby-core/src/services/themes.service.ts
+++ b/tabby-core/src/services/themes.service.ts
@@ -110,12 +110,6 @@ export class ThemesService {
             vars['--theme-bg-more'] = backgroundMore
             vars['--theme-bg-more-2'] = more(backgroundMore, 0.25).string()
 
-            // Blurred-window tab bar tint: blend the bar's own color (--theme-bg-more-2)
-            // towards the opposite extreme, so the change stays visible on schemes where
-            // the multiplicative lighten/darken above is a no-op (e.g. pure black backgrounds)
-            const tabBarBg = more(backgroundMore, 0.25)
-            vars['--theme-tab-bar-blurred-bg'] = tabBarBg.mix(Color(isDark ? 'white' : 'black'), 0.12).string()
-
             contrastPairs.push(['--theme-bg', '--theme-fg'])
             contrastPairs.push(['--theme-bg-less', '--theme-fg-less'])
             contrastPairs.push(['--theme-bg-less-2', '--theme-fg-less-2'])

--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -825,9 +825,11 @@ body:not(.no-animations) app-root .main.content .tab-bar .tabs tab-header {
         color .18s ease-out;
 }
 
-// The tab bar brightens (dims on light schemes) while the window is unfocused
+// While the window is unfocused the tab bar shifts toward the foreground colour —
+// brightening dark schemes, dimming light ones — computed from the bar's own colour
+// so it works on every theme, including pure black/white.
 app-root.window-blurred .main.content .tab-bar {
-    background: var(--theme-tab-bar-blurred-bg);
+    background: color-mix(in srgb, var(--theme-fg) 14%, var(--theme-bg-more-2));
 }
 
 body:not(.no-animations) app-root .main.content .tab-bar {

--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -86,11 +86,24 @@ $input-placeholder-color: var(--theme-fg-more-2);
 @import '~bootstrap/scss/bootstrap.scss';
 @import "./theme.vendor.scss";
 
+// Consistent hyperlink colour across themes. Must live on :root — Bootstrap
+// defines --bs-link-color-rgb there, outranking a body-level override.
+:root {
+    --bs-link-color-rgb: 116, 169, 245;
+    --bs-link-hover-color-rgb: 158, 196, 251;
+}
+
 body {
     background: var(--body-bg);
     --bs-border-color: var(--theme-bg-more-2);
     --bs-form-control-bg: var(--theme-bg-more-2);
     --bs-emphasis-color: var(--theme-fg-less-2);
+
+    // Shared focus-ring colour — referenced by theme.vars but never defined until now.
+    --focus-color: var(--theme-primary, var(--bs-primary));
+
+    // Shared dim strength for overlays (modal backdrop, drop hint, split-pane dim)
+    --overlay-dim: rgba(0, 0, 0, .4);
 }
 
 .list-group {
@@ -128,8 +141,9 @@ body {
 
 .nav-pills {
     --bs-nav-pills-border-radius: #{$nav-pills-border-radius};
-    --bs-nav-pills-link-active-color: var(--theme-primary-fg);
-    --bs-nav-pills-link-active-bg: var(--theme-primary);
+    // The active background is drawn by the sliding .nav-indicator instead
+    --bs-nav-pills-link-active-color: var(--theme-fg-less-2);
+    --bs-nav-pills-link-active-bg: transparent;
 }
 
 .nav-tabs {
@@ -173,8 +187,26 @@ body {
     }
 }
 
+// Dim strength comes from --overlay-dim; the backdrop's opacity only drives the fade
+.modal-backdrop {
+    --bs-backdrop-opacity: 1;
+    background-color: var(--overlay-dim, rgba(0, 0, 0, .4));
+}
+
 .dropdown-menu {
     --bs-dropdown-bg: var(--theme-bg-more);
+    --bs-dropdown-border-color: var(--theme-bg-more-2);
+    --bs-dropdown-border-radius: .5rem;
+    --bs-dropdown-link-hover-bg: var(--theme-bg-more-2);
+    --bs-dropdown-link-hover-color: var(--theme-fg);
+    --bs-dropdown-link-active-bg: var(--theme-primary);
+    --bs-dropdown-link-active-color: var(--theme-primary-fg);
+    padding: .35rem;
+    box-shadow: 0 .5rem 1.5rem rgba(0, 0, 0, .35);
+
+    .dropdown-item {
+        border-radius: .35rem;
+    }
 }
 
 .progress {
@@ -337,6 +369,11 @@ hotkey-input-modal {
         border-radius: $border-radius;
         margin: 0 !important;
 
+        &.list-group-item-action:not(.disabled):not(.active):hover {
+            background-color: var(--theme-bg-more-2);
+            color: var(--theme-fg);
+        }
+
         &.active {
             background-color: var(--bs-list-group-active-bg);
         }
@@ -349,18 +386,40 @@ hotkey-input-modal {
 }
 
 *::-webkit-scrollbar {
-    background: rgba(0, 0, 0, .125);
-    width: 10px;
-    margin: 5px;
+    width: 12px;
+    height: 12px;
+    background: transparent;
 }
 
+// Transparent border + padding-box clip float the thumb; the colour tracks the
+// theme foreground so it stays visible on light schemes.
 *::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, .25);
+    background: color-mix(in srgb, var(--theme-fg, #fff) 22%, transparent);
+    border-radius: 8px;
+    border: 3px solid transparent;
+    background-clip: padding-box;
+
+    &:hover {
+        background: color-mix(in srgb, var(--theme-fg, #fff) 38%, transparent);
+        background-clip: padding-box;
+    }
 }
 
 *::-webkit-scrollbar-corner,
 *::-webkit-resizer {
     opacity: 0;
+}
+
+body:not(.no-animations) {
+    scroll-behavior: smooth;
+
+    .dropdown-menu,
+    .list-group,
+    .modal-body,
+    .nav-content,
+    ngb-typeahead-window {
+        scroll-behavior: smooth;
+    }
 }
 
 search-panel {
@@ -415,8 +474,75 @@ ngx-colors-panel .opened {
     }
 }
 
-.form-control:focus {
-    border-color: var(--theme-fg-more-2);
+.form-check:not(.form-switch) .form-check-input {
+    background-color: var(--theme-bg-more-2);
+    border-color: var(--theme-bg-less);
+    cursor: pointer;
+
+    &:checked {
+        background-color: var(--theme-primary);
+        border-color: var(--theme-primary-more);
+    }
+
+    &:hover:not(:checked):not(:disabled) {
+        border-color: var(--theme-fg-more-2);
+    }
+}
+
+body:not(.no-animations) .form-check:not(.form-switch) .form-check-input {
+    transition: background-color .15s ease-out, border-color .15s ease-out;
+
+    &:checked {
+        animation: tabbyCheckPop .18s cubic-bezier(.34, 1.4, .5, 1);
+    }
+}
+
+@keyframes tabbyCheckPop {
+    from { scale: .8; }
+    to { scale: 1; }
+}
+
+// Mouse focus shows no outlines or rings; keyboard focus gets the themed
+// :focus-visible ring below (mouse clicks don't match :focus-visible on buttons).
+:focus:not(:focus-visible) {
+    outline: none !important;
+}
+
+.btn:focus, .btn:focus-visible,
+.form-control:focus, .form-select:focus, select:focus,
+.form-check-input:focus, .form-check-input:focus-visible,
+.dropdown-item:focus, .dropdown-item:focus-visible,
+.nav-link:focus, .page-link:focus, a:focus,
+.select-dropdown-toggle:focus, .select-dropdown-toggle:focus-visible {
+    box-shadow: none !important;
+}
+
+// Keyboard-only focus ring; outlines also render (system-forced) in forced-colors
+:focus-visible {
+    outline: 2px solid rgba(var(--bs-primary-rgb), .55);
+    outline-offset: 1px;
+}
+
+// Clicking into a text field matches :focus-visible — exclude them; the caret and
+// the border hint below indicate focus instead
+input:focus-visible, textarea:focus-visible, select:focus-visible,
+.form-control:focus-visible, .form-select:focus-visible {
+    outline: none !important;
+}
+
+// Soft accent border as the input focus hint (Bootstrap's default is bright blue)
+.form-control:focus, .form-select:focus, select:focus,
+.form-check-input:focus, .select-dropdown-toggle:focus {
+    border-color: rgba(var(--bs-primary-rgb), .5);
+}
+
+// High-contrast mode ignores box-shadow/border colour — restore an outline for a11y.
+@media screen and (forced-colors: active) {
+    .form-control:focus,
+    .form-select:focus,
+    .form-check-input:focus {
+        outline: 2px solid activetext;
+    }
 }
 
 .accordion {
@@ -441,4 +567,277 @@ window-controls {
     button svg {
         fill: var(--theme-fg) !important;
     }
+}
+
+// These render as href-less <a>, <button> or ngb nav tabs — no native pointer cursor
+.list-group-item-action:not(.disabled),
+.nav-link:not(.disabled),
+a.description {
+    cursor: pointer;
+}
+
+.nav-pills .nav-link:not(.active):hover {
+    background-color: var(--theme-bg-less);
+    color: var(--theme-fg-less);
+}
+
+// Hover/focus feedback: paint-only properties, so nothing reflows
+body:not(.no-animations) {
+    a,
+    .btn,
+    .nav-link,
+    .list-group-item,
+    .dropdown-item,
+    .page-link,
+    .link-card,
+    .tree-item,
+    .collapse-item,
+    .hover-reveal,
+    .form-control,
+    .form-select {
+        transition:
+            background-color .12s ease-out,
+            border-color .12s ease-out,
+            color .12s ease-out,
+            fill .12s ease-out,
+            box-shadow .12s ease-out,
+            opacity .12s ease-out,
+            scale .1s ease-out;
+    }
+
+    .btn:active:not(:disabled):not(.disabled),
+    .dropdown-item:active:not(.disabled),
+    .list-group-item-action:active:not(.disabled) {
+        scale: .97;
+    }
+}
+
+// Bootstrap ships these transitions ungated — neutralise them when animations are off
+body.no-animations {
+    .form-control,
+    .form-select,
+    .form-check-input {
+        transition: none;
+    }
+}
+
+// Modal animation. The window fades (ng-bootstrap times the close against this
+// transition); the dialog scale/slide is an enter-only keyframe — replaying it in
+// reverse on close would lurch the dialog upward while the app is busy.
+body:not(.no-animations) ngb-modal-window {
+    transition: opacity .12s ease-out;
+    opacity: 0;
+
+    // Bootstrap's .modal.fade otherwise slides the dialog to translate(0,-50px) the
+    // moment .show drops; &.modal matches its 3-class specificity
+    &.modal .modal-dialog {
+        transform: none;
+        transition: none;
+    }
+
+    &.show {
+        opacity: 1;
+
+        .modal-dialog {
+            animation: tabbyModalIn .16s cubic-bezier(.3, .7, .2, 1);
+        }
+    }
+}
+
+@keyframes tabbyModalIn {
+    from {
+        scale: .97;
+        translate: 0 -8px;
+    }
+    to {
+        scale: 1;
+        translate: 0 0;
+    }
+}
+
+// Chromium natively drags <a href> and <img>, and many controls here are anchors.
+// CDK drag-drop is pointer-based and unaffected.
+a, button, img, svg,
+.btn, .nav-link, .list-group-item, .dropdown-item,
+.tree-item, .link-card, .breadcrumb-item, .page-link {
+    -webkit-user-drag: none;
+}
+
+// Shared navigation design (settings sidebar + selector modal): a sliding surface
+// (.nav-indicator, positioned by NavIndicatorDirective) plus an accent bar on the
+// active item itself, so the active cue never lags behind the slide.
+@mixin nav-active-item {
+    position: relative;
+    z-index: 1;
+
+    &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 26%;
+        bottom: 26%;
+        width: 3px;
+        border-radius: 3px;
+        background: var(--theme-primary);
+        opacity: 0;
+    }
+
+    &.active::before {
+        opacity: 1;
+    }
+}
+
+.nav-indicator {
+    position: absolute;
+    z-index: 0;
+    border-radius: var(--bs-nav-pills-border-radius, .4rem);
+    background: var(--theme-bg-less-2);
+    pointer-events: none;
+    opacity: 0;
+}
+
+.nav-pills .nav-link {
+    @include nav-active-item;
+}
+
+selector-modal .list-group-item {
+    @include nav-active-item;
+}
+
+body:not(.no-animations) {
+    .nav-pills .nav-link::before,
+    selector-modal .list-group-item::before {
+        transition: opacity .15s ease-out;
+    }
+}
+
+// Selector rows share the sidebar navigation palette
+selector-modal .list-group {
+    --bs-list-group-active-bg: transparent;
+    --bs-list-group-active-color: var(--theme-fg-less-2);
+
+    .list-group-item.list-group-item-action:not(.disabled):not(.active):hover {
+        background-color: var(--theme-bg-less);
+        color: var(--theme-fg-less);
+    }
+}
+
+// The key-hint badges are *ngIf-ed onto the active row; keyframes run on insertion
+body:not(.no-animations) selector-modal .badge {
+    animation: tabbyBadgeIn .16s ease-out;
+}
+
+@keyframes tabbyBadgeIn {
+    from {
+        opacity: 0;
+        translate: 6px 0;
+    }
+    to {
+        opacity: 1;
+        translate: 0 0;
+    }
+}
+
+// Menu pinned by DropdownCloseAnimationDirective while its close fade plays
+.dropdown-menu-closing {
+    z-index: 1060;
+    pointer-events: none !important;
+}
+
+// Segmented btn-check toggles: SegmentedToggleIndicatorDirective slides the group's
+// ::before behind the checked segment via the --segment-* variables. A real child
+// element would shift Bootstrap's nth-child border-radius rules.
+.btn-group.has-segment-indicator {
+    > .btn-check:checked + .btn {
+        --bs-btn-active-bg: transparent;
+        --bs-btn-active-border-color: transparent;
+    }
+
+    > .btn-check + .btn {
+        --bs-btn-hover-bg: var(--theme-secondary-less-2, var(--theme-bg-less));
+        --bs-btn-hover-border-color: transparent;
+    }
+
+    &::before {
+        content: '';
+        position: absolute;
+        z-index: 0;
+        left: var(--segment-left, 0);
+        top: var(--segment-top, 0);
+        width: var(--segment-width, 0);
+        height: var(--segment-height, 0);
+        opacity: var(--segment-opacity, 0);
+        border-radius: var(--bs-border-radius, .4rem);
+        background: var(--theme-secondary-active-bg, rgba(255, 255, 255, .12));
+        pointer-events: none;
+    }
+
+    &.segment-indicator-init::before {
+        transition: none !important;
+    }
+}
+
+body:not(.no-animations) .btn-group.has-segment-indicator::before {
+    transition:
+        left .22s cubic-bezier(.4, .85, .3, 1),
+        top .22s cubic-bezier(.4, .85, .3, 1),
+        width .22s cubic-bezier(.4, .85, .3, 1),
+        height .22s cubic-bezier(.4, .85, .3, 1),
+        opacity .15s ease-out;
+}
+
+// Forced colors strip the indicator surfaces — mark the active elements directly
+@media (forced-colors: active) {
+    .btn-group.has-segment-indicator {
+        &::before {
+            display: none;
+        }
+
+        > .btn-check:checked + .btn {
+            forced-color-adjust: none;
+            background: Highlight;
+            color: HighlightText;
+        }
+    }
+
+    .nav-pills .nav-link.active {
+        outline: 2px solid Highlight;
+        outline-offset: -2px;
+    }
+}
+
+// Smooth active/passive tab colour fade (the base style only transitions width)
+body:not(.no-animations) app-root .main.content .tab-bar .tabs tab-header {
+    transition:
+        width .125s ease-out,
+        background-color .18s ease-out,
+        color .18s ease-out;
+}
+
+// The tab bar brightens while the window is unfocused
+app-root.window-blurred .main.content .tab-bar {
+    background: var(--theme-bg-less);
+}
+
+body:not(.no-animations) app-root .main.content .tab-bar {
+    transition: background-color .25s ease-out;
+}
+
+// Dropdown open animation. Keyframes (unlike transitions) restart when the menu
+// flips from display:none to block, so the first open animates too; the close fade
+// is driven by DropdownCloseAnimationDirective.
+body:not(.no-animations) .dropdown-menu.show {
+    animation: tabbyDropdownIn .14s cubic-bezier(.3, .7, .2, 1);
+    transform-origin: top center;
+
+    &[data-popper-placement^='top'] { transform-origin: bottom center; }
+    &[data-popper-placement$='start'] { transform-origin: top left; }
+    &[data-popper-placement$='end'] { transform-origin: top right; }
+    &[data-popper-placement='top-start'] { transform-origin: bottom left; }
+    &[data-popper-placement='top-end'] { transform-origin: bottom right; }
+}
+
+@keyframes tabbyDropdownIn {
+    from { opacity: 0; scale: .97; }
+    to { opacity: 1; scale: 1; }
 }

--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -111,6 +111,12 @@ body {
     --active-overlay: color-mix(in srgb, var(--theme-fg, #fff) 16%, transparent);
 }
 
+// Themed text selection everywhere in the UI (terminal panes render their own);
+// replaces the browser-default blue with the theme accent
+::selection {
+    background: color-mix(in srgb, var(--theme-primary, #7aa2f7) 40%, transparent);
+}
+
 .list-group {
     --bs-list-group-bg: var(--theme-bg-more);
     --bs-list-group-border-color: var(--theme-bg-more-2);

--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -21,8 +21,8 @@ app-root {
                     fill-opacity: 0.75;
                 }
 
-                &:hover { background: rgba(0, 0, 0, .125) !important; }
-                &:active { background: rgba(0, 0, 0, .25) !important; }
+                &:hover { background: var(--hover-overlay) !important; }
+                &:active { background: var(--active-overlay) !important; }
             }
 
             &>.tabs {
@@ -104,6 +104,11 @@ body {
 
     // Shared dim strength for overlays (modal backdrop, drop hint, split-pane dim)
     --overlay-dim: rgba(0, 0, 0, .4);
+
+    // Shared hover/pressed overlays — foreground-based so they stay visible on any
+    // surface colour (a black-based dim disappears on dark surfaces)
+    --hover-overlay: color-mix(in srgb, var(--theme-fg, #fff) 10%, transparent);
+    --active-overlay: color-mix(in srgb, var(--theme-fg, #fff) 16%, transparent);
 }
 
 .list-group {

--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -201,11 +201,21 @@ body {
     --bs-dropdown-link-hover-color: var(--theme-fg);
     --bs-dropdown-link-active-bg: var(--theme-primary);
     --bs-dropdown-link-active-color: var(--theme-primary-fg);
+    --bs-dropdown-header-color: var(--theme-fg-less);
     padding: .35rem;
     box-shadow: 0 .5rem 1.5rem rgba(0, 0, 0, .35);
 
     .dropdown-item {
         border-radius: .35rem;
+        cursor: pointer;
+
+        &:not(.disabled):not(.active):hover,
+        &:not(.disabled):not(.active):focus-visible {
+            // Bootstrap's hover bg is often indistinguishable from --theme-bg-more;
+            // tint from the menu surface so hover reads on every scheme.
+            background-color: color-mix(in srgb, var(--theme-fg) 8%, var(--theme-bg-more));
+            color: var(--theme-fg);
+        }
     }
 }
 
@@ -572,6 +582,7 @@ window-controls {
 // These render as href-less <a>, <button> or ngb nav tabs — no native pointer cursor
 .list-group-item-action:not(.disabled),
 .nav-link:not(.disabled),
+.dropdown-item:not(.disabled),
 a.description {
     cursor: pointer;
 }
@@ -814,9 +825,9 @@ body:not(.no-animations) app-root .main.content .tab-bar .tabs tab-header {
         color .18s ease-out;
 }
 
-// The tab bar brightens while the window is unfocused
+// The tab bar brightens (dims on light schemes) while the window is unfocused
 app-root.window-blurred .main.content .tab-bar {
-    background: var(--theme-bg-less);
+    background: var(--theme-tab-bar-blurred-bg);
 }
 
 body:not(.no-animations) app-root .main.content .tab-bar {

--- a/tabby-electron/src/pty.ts
+++ b/tabby-electron/src/pty.ts
@@ -104,6 +104,11 @@ export class ElectronPTYProxy extends PTYProxy {
 
     async getChildProcessesInternal (truePID: number): Promise<ChildProcess[]> {
         if (process.platform === 'darwin') {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (!macOSNativeProcessList) {
+                // a missing optional native module must not make tabs unclosable
+                return []
+            }
             const processes = await macOSNativeProcessList.getProcessList()
             return processes.filter(x => x.ppid === truePID).map(p => ({
                 pid: p.pid,
@@ -112,6 +117,10 @@ export class ElectronPTYProxy extends PTYProxy {
             }))
         }
         if (process.platform === 'win32') {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (!windowsProcessTree) {
+                return []
+            }
             return new Promise<ChildProcess[]>(resolve => {
                 windowsProcessTree.getProcessTree(truePID, tree => {
                     resolve(tree ? tree.children.map(child => ({

--- a/tabby-electron/src/pty.ts
+++ b/tabby-electron/src/pty.ts
@@ -15,7 +15,7 @@ try {
 
 export class ElectronPTYInterface extends PTYInterface {
     async spawn (...options: any[]): Promise<PTYProxy> {
-        const id = ipcRenderer.sendSync('pty:spawn', ...options)
+        const id = await ipcRenderer.invoke('pty:spawn', ...options)
         return new ElectronPTYProxy(id)
     }
 
@@ -30,39 +30,45 @@ export class ElectronPTYInterface extends PTYInterface {
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ElectronPTYProxy extends PTYProxy {
     private subscriptions: Map<string, any> = new Map()
-    private truePID: Promise<number>
+    private directPID: Promise<number>
+    private truePID: number|null = null
 
     constructor (
         private id: string,
     ) {
         super()
-        this.truePID = new Promise(async (resolve) => {
-            let pid = await this.getPID()
-            try {
-                await new Promise(r => setTimeout(r, 2000))
-
-                // Retrieve any possible single children now that shell has fully started
-                let processes = await this.getChildProcessesInternal(pid)
-                while (pid && processes.length === 1) {
-                    if (!processes[0].pid) {
-                        break
-                    }
-                    pid = processes[0].pid
-                    processes = await this.getChildProcessesInternal(pid)
-                }
-            } finally {
-                resolve(pid)
-            }
-        })
-        this.truePID = this.truePID.catch(() => this.getPID())
+        this.directPID = this.getPID()
+        this.refineTruePID()
     }
 
     getID (): string {
         return this.id
     }
 
-    getTruePID (): Promise<number> {
-        return this.truePID
+    // Returns the best PID known so far: the directly spawned process until the
+    // delayed child-chain probe completes. Previously this awaited that probe's
+    // fixed 2s delay, which stalled every consumer (e.g. opening a new tab
+    // inherits the active tab's CWD) for up to 2s after a spawn.
+    async getTruePID (): Promise<number> {
+        return this.truePID ?? this.directPID
+    }
+
+    private async refineTruePID (): Promise<void> {
+        let pid = await this.directPID
+        try {
+            await new Promise(r => setTimeout(r, 2000))
+
+            // Retrieve any possible single children now that shell has fully started
+            let processes = await this.getChildProcessesInternal(pid)
+            while (pid && processes.length === 1) {
+                if (!processes[0].pid) {
+                    break
+                }
+                pid = processes[0].pid
+                processes = await this.getChildProcessesInternal(pid)
+            }
+        } catch { }
+        this.truePID = pid
     }
 
     async getPID (): Promise<number> {

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -18,6 +18,8 @@ const fontManager = require('fontmanager-redux') // eslint-disable-line
 try {
     // eslint-disable-next-line no-var
     var windowsProcessTreeNative = require('@tabby-gang/windows-process-tree/build/Release/windows_process_tree.node')
+} catch { }
+try {
     // eslint-disable-next-line no-var
     var wnr = require('windows-native-registry')
 } catch { }
@@ -80,7 +82,7 @@ export class ElectronPlatformService extends PlatformService {
     }
 
     async isProcessRunning (name: string): Promise<boolean> {
-        if (this.hostApp.platform === Platform.Windows) {
+        if (this.hostApp.platform === Platform.Windows && windowsProcessTreeNative) { // eslint-disable-line block-scoped-var
             return new Promise<boolean>(resolve => {
                 windowsProcessTreeNative.getProcessList(list => { // eslint-disable-line block-scoped-var
                     resolve(list.some(x => x.name === name))

--- a/tabby-electron/src/services/platform.service.ts
+++ b/tabby-electron/src/services/platform.service.ts
@@ -458,6 +458,7 @@ class ElectronFileDownload extends FileDownload {
 
 class ElectronDirectoryDownload extends DirectoryDownload {
     private powerSaveBlocker = 0
+    private children: FileDownload[] = []
 
     constructor (
         private basePath: string,
@@ -483,18 +484,60 @@ class ElectronDirectoryDownload extends DirectoryDownload {
         return this.getTotalSize()
     }
 
+    // entry names come from the remote server — never let them escape basePath
+    private resolveSafe (relativePath: string): string {
+        if (relativePath.includes('\0')) {
+            throw new Error('Invalid remote file name')
+        }
+        const base = path.normalize(this.basePath + path.sep)
+        const fullPath = path.normalize(path.join(this.basePath, relativePath))
+        if (!(fullPath + path.sep).startsWith(base)) {
+            throw new Error(`Refusing to write outside the download directory: ${relativePath}`)
+        }
+        return fullPath
+    }
+
     async createDirectory (relativePath: string): Promise<void> {
-        const fullPath = path.join(this.basePath, relativePath)
-        await fs.mkdir(fullPath, { recursive: true })
+        await fs.mkdir(this.resolveSafe(relativePath), { recursive: true })
     }
 
     async createFile (relativePath: string, mode: number, size: number): Promise<FileDownload> {
-        const fullPath = path.join(this.basePath, relativePath)
+        const fullPath = this.resolveSafe(relativePath)
         await fs.mkdir(path.dirname(fullPath), { recursive: true })
 
         const fileDownload = new ElectronFileDownload(fullPath, mode, size, this.electron)
         await wrapPromise(this.zone, fileDownload.open())
+
+        // chain the child's progress into this folder transfer, which otherwise
+        // sits at 0% no matter how much has been downloaded
+        this.children.push(fileDownload)
+        const originalWrite = fileDownload.write.bind(fileDownload)
+        fileDownload.write = async (buffer: Uint8Array) => {
+            await originalWrite(buffer)
+            this.increaseProgress(buffer.length)
+            if (fileDownload.isComplete()) {
+                this.children = this.children.filter(x => x !== fileDownload)
+            }
+        }
+        const originalClose = fileDownload.close.bind(fileDownload)
+        fileDownload.close = () => {
+            this.children = this.children.filter(x => x !== fileDownload)
+            originalClose()
+        }
         return fileDownload
+    }
+
+    getChildren (): FileTransfer[] {
+        return this.children
+    }
+
+    cancel (): void {
+        // in-flight children would otherwise stream to completion — their
+        // download loops only check their own cancelled flag
+        for (const child of [...this.children]) {
+            child.cancel()
+        }
+        super.cancel()
     }
 
     close (): void {

--- a/tabby-local/src/components/terminalTab.component.ts
+++ b/tabby-local/src/components/terminalTab.component.ts
@@ -123,6 +123,9 @@ export class TerminalTabComponent extends BaseTerminalTabComponent<LocalProfile>
     }
 
     async canClose (): Promise<boolean> {
+        if (!this.config.store.terminal.warnOnClose) {
+            return true
+        }
         const children = await this.session?.getChildProcesses()
         if (!children?.length) {
             return true

--- a/tabby-local/src/components/terminalTab.component.ts
+++ b/tabby-local/src/components/terminalTab.component.ts
@@ -1,6 +1,6 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, Input, Injector, Inject, Optional } from '@angular/core'
-import { BaseTabProcess, WIN_BUILD_CONPTY_SUPPORTED, isWindowsBuild, GetRecoveryTokenOptions } from 'tabby-core'
+import { BaseTabProcess, WIN_BUILD_CONPTY_SUPPORTED, isWindowsBuild, GetRecoveryTokenOptions, Platform } from 'tabby-core'
 import { BaseTerminalTabComponent } from 'tabby-terminal'
 import { LocalProfile, SessionOptions, UACService } from '../api'
 import { Session } from '../session'
@@ -126,6 +126,18 @@ export class TerminalTabComponent extends BaseTerminalTabComponent<LocalProfile>
     ngOnDestroy (): void {
         super.ngOnDestroy()
         this.session?.destroy()
+    }
+
+    // ConPTY reports the spawned executable's path as the initial terminal title —
+    // ignore it so the tab keeps the profile name until the shell reports a real one
+    protected shouldSetDynamicTitle (title: string): boolean {
+        if (this.hostApp.platform === Platform.Windows) {
+            const basename = (path: string) => path.split(/[\\/]/).pop()?.toLowerCase()
+            if (basename(title) === basename(this.profile.options.command)) {
+                return false
+            }
+        }
+        return true
     }
 
     /**

--- a/tabby-local/src/components/terminalTab.component.ts
+++ b/tabby-local/src/components/terminalTab.component.ts
@@ -1,4 +1,5 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
+import { first } from 'rxjs'
 import { Component, Input, Injector, Inject, Optional } from '@angular/core'
 import { BaseTabProcess, WIN_BUILD_CONPTY_SUPPORTED, isWindowsBuild, GetRecoveryTokenOptions, Platform } from 'tabby-core'
 import { BaseTerminalTabComponent } from 'tabby-terminal'
@@ -46,10 +47,30 @@ export class TerminalTabComponent extends BaseTerminalTabComponent<LocalProfile>
         })
 
         super.ngOnInit()
+
+        // Spawn the shell as soon as the tab is focused instead of waiting for the
+        // terminal frontend (WebGL init + first measure — hundreds of ms): the shell
+        // boots in parallel, its output is held in the session's initial data buffer,
+        // and the estimated size is corrected once the frontend reports real
+        // dimensions. Background (e.g. recovered) tabs stay lazy as before.
+        const spawnEarly = () => {
+            if (!this.session) {
+                this.initializeSession(80, 30)
+            }
+        }
+        if (this.hasFocus) {
+            spawnEarly()
+        } else {
+            this.focused$.pipe(first()).subscribe(spawnEarly)
+        }
     }
 
     protected onFrontendReady (): void {
-        this.initializeSession(this.size.columns, this.size.rows)
+        if (this.session) {
+            this.session.resize(this.size.columns, this.size.rows)
+        } else {
+            this.initializeSession(this.size.columns, this.size.rows)
+        }
         this.savedStateIsLive = this.profile.options.restoreFromPTYID === this.session?.getID()
         super.onFrontendReady()
     }

--- a/tabby-local/src/config.ts
+++ b/tabby-local/src/config.ts
@@ -30,6 +30,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             hotkeys: {
                 'new-tab': [
                     'Ctrl-Shift-T',
+                    'Ctrl-T',
                 ],
             },
         },
@@ -40,6 +41,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             hotkeys: {
                 'new-tab': [
                     'Ctrl-Shift-T',
+                    'Ctrl-T',
                 ],
             },
         },

--- a/tabby-plugin-manager/src/components/pluginsSettingsTab.component.ts
+++ b/tabby-plugin-manager/src/components/pluginsSettingsTab.component.ts
@@ -98,7 +98,7 @@ export class PluginsSettingsTabComponent {
         try {
             await this.pluginManager.installPlugin(plugin)
             this.busy.delete(plugin.name)
-            this.config.requestRestart()
+            this.config.requestRestartForced()
         } catch (err) {
             console.error('Error installing plugin', plugin.name, err)
             this.erroredPlugin = plugin.name
@@ -113,7 +113,7 @@ export class PluginsSettingsTabComponent {
         try {
             await this.pluginManager.uninstallPlugin(plugin)
             this.busy.delete(plugin.name)
-            this.config.requestRestart()
+            this.config.requestRestartForced()
         } catch (err) {
             console.error('Error uninstalling plugin', plugin.name, err)
             this.erroredPlugin = plugin.name
@@ -154,12 +154,12 @@ export class PluginsSettingsTabComponent {
     enablePlugin (plugin: PluginInfo) {
         this.config.store.pluginBlacklist = this.config.store.pluginBlacklist.filter(x => x !== plugin.name)
         this.config.save()
-        this.config.requestRestart()
+        this.config.requestRestartForced()
     }
 
     disablePlugin (plugin: PluginInfo) {
         this.config.store.pluginBlacklist = [...this.config.store.pluginBlacklist, plugin.name]
         this.config.save()
-        this.config.requestRestart()
+        this.config.requestRestartForced()
     }
 }

--- a/tabby-serial/src/components/serialProfileSettings.component.pug
+++ b/tabby-serial/src/components/serialProfileSettings.component.pug
@@ -51,15 +51,10 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
             .form-line
                 .header
                     .title(translate) Parity
-                select.form-control(
-                    type='text',
-                    [(ngModel)]='profile.options.parity'
+                select-dropdown(
+                    [(ngModel)]='profile.options.parity',
+                    [options]='parityOptions'
                 )
-                    option(value='none', translate) None
-                    option(value='even') Even
-                    option(value='odd') Odd
-                    option(value='mark', ng:if='hostApp.platform === Platform.Windows') Mark
-                    option(value='space', ng:if='hostApp.platform === Platform.Windows') Space
 
             .form-line
                 .header

--- a/tabby-serial/src/components/serialProfileSettings.component.ts
+++ b/tabby-serial/src/components/serialProfileSettings.component.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component } from '@angular/core'
 import { debounceTime, distinctUntilChanged, map } from 'rxjs'
-import { FullyDefined, HostAppService, Platform, ProfileSettingsComponent } from 'tabby-core'
+import { FullyDefined, HostAppService, Platform, ProfileSettingsComponent, TranslateService } from 'tabby-core'
 import { SerialPortInfo, BAUD_RATES, SerialProfile } from '../api'
 import { SerialService } from '../services/serial.service'
 import { SerialProfilesService } from '../profiles'
@@ -14,11 +15,25 @@ export class SerialProfileSettingsComponent implements ProfileSettingsComponent<
     profile: FullyDefined<SerialProfile>
     foundPorts: SerialPortInfo[]
     Platform = Platform
+    parityOptions: { value: any, name: string }[] = []
 
     constructor (
         private serial: SerialService,
         public hostApp: HostAppService,
-    ) { }
+        translate: TranslateService,
+    ) {
+        this.parityOptions = [
+            { value: 'none', name: translate.instant(_('None')) },
+            { value: 'even', name: 'Even' },
+            { value: 'odd', name: 'Odd' },
+        ]
+        if (hostApp.platform === Platform.Windows) {
+            this.parityOptions.push(
+                { value: 'mark', name: 'Mark' },
+                { value: 'space', name: 'Space' },
+            )
+        }
+    }
 
     portsAutocomplete = text$ => text$.pipe(map(() => {
         return this.foundPorts.map(x => x.name)

--- a/tabby-settings/src/components/editProfileModal.component.pug
+++ b/tabby-settings/src/components/editProfileModal.component.pug
@@ -72,13 +72,10 @@
                 .header
                     .title(translate) When a session ends
                     .description(*ngIf='profile.behaviorOnSessionEnd == "auto"', translate) Only close the tab when session is explicitly terminated
-                select.form-control(
+                select-dropdown(
                     [(ngModel)]='profile.behaviorOnSessionEnd',
+                    [options]='behaviorOnSessionEndOptions',
                 )
-                    option(ngValue='auto', translate) Auto
-                    option(ngValue='keep', translate) Keep
-                    option(*ngIf='isConnectable()', ngValue='reconnect', translate) Reconnect
-                    option(ngValue='close', translate) Close
             
             .form-line(*ngIf='isConnectable()')
                 .header

--- a/tabby-settings/src/components/editProfileModal.component.ts
+++ b/tabby-settings/src/components/editProfileModal.component.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Observable, OperatorFunction, debounceTime, map, distinctUntilChanged } from 'rxjs'
 import { Component, Input, ViewChild, ViewContainerRef, ComponentFactoryResolver, Injector } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { PartialProfileGroup, Profile, ProfileProvider, ProfileSettingsComponent, ProfilesService, TAB_COLORS, ProfileGroup, ConnectableProfileProvider, FullyDefined, ConfigProxy } from 'tabby-core'
+import { PartialProfileGroup, Profile, ProfileProvider, ProfileSettingsComponent, ProfilesService, TAB_COLORS, ProfileGroup, ConnectableProfileProvider, FullyDefined, ConfigProxy, TranslateService } from 'tabby-core'
 
 const iconsData = require('../../../tabby-core/src/icons.json')
 const iconsClassList = Object.keys(iconsData).map(
@@ -22,6 +23,7 @@ export class EditProfileModalComponent<P extends Profile, PP extends ProfileProv
     @Input() defaultsMode: 'enabled'|'group'|'disabled' = 'disabled'
     @Input() profileGroup: PartialProfileGroup<ProfileGroup> | undefined
     groups: PartialProfileGroup<ProfileGroup>[]
+    behaviorOnSessionEndOptions: { value: any, name: string }[] = []
     @ViewChild('placeholder', { read: ViewContainerRef }) placeholder: ViewContainerRef
 
     protected profile: FullyDefined<P> & ConfigProxy<FullyDefined<P>>
@@ -32,6 +34,7 @@ export class EditProfileModalComponent<P extends Profile, PP extends ProfileProv
         private componentFactoryResolver: ComponentFactoryResolver,
         private profilesService: ProfilesService,
         private modalInstance: NgbActiveModal,
+        private translate: TranslateService,
     ) {
         if (this.defaultsMode === 'disabled') {
             this.profilesService.getProfileGroups().then(groups => {
@@ -57,6 +60,12 @@ export class EditProfileModalComponent<P extends Profile, PP extends ProfileProv
 
     ngOnInit () {
         this.profile = this.profilesService.getConfigProxyForProfile<P>(this.partialProfile, { skipGlobalDefaults: this.defaultsMode === 'enabled', skipGroupDefaults: this.defaultsMode === 'group' })
+        this.behaviorOnSessionEndOptions = [
+            { value: 'auto', name: this.translate.instant(_('Auto')) },
+            { value: 'keep', name: this.translate.instant(_('Keep')) },
+            ...this.isConnectable() ? [{ value: 'reconnect', name: this.translate.instant(_('Reconnect')) }] : [],
+            { value: 'close', name: this.translate.instant(_('Close')) },
+        ]
     }
 
     ngAfterViewInit () {

--- a/tabby-settings/src/components/hotkeySettingsTab.component.scss
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.scss
@@ -1,3 +1,3 @@
-.hotkey-name-cell > div {
+.hotkey-name-cell > span {
     cursor: pointer;
 }

--- a/tabby-settings/src/components/multiHotkeyInput.component.scss
+++ b/tabby-settings/src/components/multiHotkeyInput.component.scss
@@ -29,8 +29,13 @@
     flex: auto;
     opacity: 0;
     white-space: nowrap;
+    cursor: pointer;
 
     &:first-child {
         opacity: 1;
     }
+}
+
+body:not(.no-animations) .add {
+    transition: opacity .12s ease-out;
 }

--- a/tabby-settings/src/components/profilesSettingsTab.component.pug
+++ b/tabby-settings/src/components/profilesSettingsTab.component.pug
@@ -119,26 +119,22 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                     .title(translate) Terminal identification
                     .description(translate) How Tabby presents itself through environment vars
 
-                select.form-control(
+                select-dropdown(
                     [(ngModel)]='config.store.terminal.identification',
+                    [options]='identificationOptions',
                     (ngModelChange)='config.save()',
                 )
-                    option(ngValue='wt', translation) Windows Terminal
-                    option(ngValue='cygwin', translation) Cygwin
 
             .form-line
                 .header
                     .title(translate) Default "Connect to" type
                     .description(translate) Default connection type used by quick connect feature (ex. SSH, Telnet)
 
-                select.form-control(
+                select-dropdown(
                     [(ngModel)]='config.store.defaultQuickConnectProvider',
+                    [options]='quickConnectProviderOptions',
                     (ngModelChange)='config.save()',
                 )
-                    option(
-                        *ngFor='let provider of getQuickConnectProviders()',
-                        [ngValue]='provider.id'
-                    ) {{provider.name}}
 
             .form-line.content-box
                 .header

--- a/tabby-settings/src/components/profilesSettingsTab.component.pug
+++ b/tabby-settings/src/components/profilesSettingsTab.component.pug
@@ -8,20 +8,11 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
                 .header
                     .title(translate) Default profile for new tabs
 
-                select.form-control(
+                select-dropdown(
                     [(ngModel)]='config.store.terminal.profile',
+                    [options]='defaultProfileOptions',
                     (ngModelChange)='config.save()',
                 )
-                    optgroup([label]='"Custom Profiles"|translate', *ngIf='customProfiles?.length > 0')
-                        option(
-                            *ngFor='let profile of customProfiles',
-                            [ngValue]='profile.id'
-                        ) {{profile.name}}
-                    optgroup([label]='"Built-in Profiles"|translate')
-                        option(
-                            *ngFor='let profile of builtinProfiles',
-                            [ngValue]='profile.id'
-                        ) {{profile.name}}
 
             .d-flex.mb-3
                 .input-group

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -29,6 +29,12 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
 
     filter = ''
     Platform = Platform
+    identificationOptions = [
+        { value: 'wt', name: 'Windows Terminal' },
+        { value: 'cygwin', name: 'Cygwin' },
+    ]
+
+    quickConnectProviderOptions: { value: any, name: string }[] = []
     private descriptionCache = new Map<string, string|null>()
 
     constructor (
@@ -43,6 +49,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     ) {
         super()
         this.profileProviders.sort((a, b) => a.name.localeCompare(b.name))
+        this.quickConnectProviderOptions = this.getQuickConnectProviders().map(provider => ({ value: provider.id, name: provider.name }))
     }
 
     async ngOnInit (): Promise<void> {

--- a/tabby-settings/src/components/profilesSettingsTab.component.ts
+++ b/tabby-settings/src/components/profilesSettingsTab.component.ts
@@ -8,6 +8,8 @@ import { EditProfileGroupModalComponent, EditProfileGroupModalComponentResult } 
 
 _('Filter')
 _('Ungrouped')
+_('Custom Profiles')
+_('Built-in Profiles')
 
 interface CollapsableProfileGroup extends ProfileGroup {
     collapsed: boolean
@@ -35,6 +37,7 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
     ]
 
     quickConnectProviderOptions: { value: any, name: string }[] = []
+    defaultProfileOptions: { value: any, name: string, group: string }[] = []
     private descriptionCache = new Map<string, string|null>()
 
     constructor (
@@ -64,6 +67,12 @@ export class ProfilesSettingsTabComponent extends BaseComponent {
         this.builtinProfiles = allProfiles.filter(x => x.isBuiltin && !x.isTemplate)
         this.templateProfiles = allProfiles.filter(x => x.isBuiltin && x.isTemplate)
         this.customProfiles = allProfiles.filter(x => !x.isBuiltin)
+        this.defaultProfileOptions = [
+            ...this.customProfiles.length > 0
+                ? this.customProfiles.map(p => ({ value: p.id, name: p.name, group: this.translate.instant('Custom Profiles') }))
+                : [],
+            ...this.builtinProfiles.map(p => ({ value: p.id, name: p.name, group: this.translate.instant('Built-in Profiles') })),
+        ]
 
         this.descriptionCache.clear()
         for (const p of allProfiles) {

--- a/tabby-settings/src/components/settingsTab.component.pug
+++ b/tabby-settings/src/components/settingsTab.component.pug
@@ -1,5 +1,5 @@
 .content
-    ul.nav-pills(ngbNav, #nav='ngbNav', [activeId]='activeTab', orientation='vertical')
+    ul.nav-pills(ngbNav, #nav='ngbNav', animatedNavIndicator='.nav-link.active', [activeId]='activeTab', orientation='vertical')
         li(ngbNavItem='application')
             a(ngbNavLink)
                 i.fas.fa-fw.fa-window-maximize.me-2
@@ -66,12 +66,11 @@
                             a.description((click)='homeBase.openTranslations()')
                                 span(translate) Help translate Tabby
                                 i.fas.fa-external-link-square-alt.ms-1
-                        select.form-control([(ngModel)]='config.store.language', (ngModelChange)='saveConfiguration(true)')
-                            option([ngValue]='null', translate) Automatic
-                            option(
-                                [value]='lang.code',
-                                *ngFor='let lang of allLanguages'
-                            ) {{lang.name}}
+                        select-dropdown(
+                            [(ngModel)]='config.store.language',
+                            [options]='languageOptions',
+                            (ngModelChange)='saveConfiguration(true)'
+                        )
 
                     .form-line(*ngIf='platform.isShellIntegrationSupported()')
                         .header

--- a/tabby-settings/src/components/settingsTab.component.scss
+++ b/tabby-settings/src/components/settingsTab.component.scss
@@ -35,10 +35,24 @@
 
         > .nav {
             padding: 20px 10px;
-            width: 222px;
+            // Auto-adjust to label length (localized labels vary), never h-scroll
+            width: auto;
+            min-width: 222px;
+            max-width: 320px;
             flex: none;
             overflow-y: auto;
+            overflow-x: hidden;
             flex-wrap: nowrap;
+
+            .nav-link {
+                white-space: nowrap;
+
+                span {
+                    min-width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
         }
 
         > .tab-content {

--- a/tabby-settings/src/components/settingsTab.component.ts
+++ b/tabby-settings/src/components/settingsTab.component.ts
@@ -38,6 +38,7 @@ export class SettingsTabComponent extends BaseTabComponent {
     updateAvailable = false
     showConfigDefaults = false
     allLanguages = LocaleService.allLanguages
+    languageOptions: { value: any, name: string }[] = []
     @HostBinding('class.pad-window-controls') padWindowControls = false
 
     constructor (
@@ -60,6 +61,11 @@ export class SettingsTabComponent extends BaseTabComponent {
         this.settingsProviders.sort((a, b) => a.weight - b.weight + a.title.localeCompare(b.title))
 
         this.configDefaults = yaml.dump(config.getDefaults())
+
+        this.languageOptions = [
+            { value: null, name: translate.instant(_('Automatic')) },
+            ...this.allLanguages.map(lang => ({ value: lang.code, name: lang.name })),
+        ]
 
         const onConfigChange = () => {
             this.configFile = config.readRaw()

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -3,11 +3,11 @@ h3.mb-3(translate) Window
 .form-line(*ngIf='themes.length > 1')
     .header
         .title(translate) Theme
-    select.form-control(
+    select-dropdown(
         [(ngModel)]='config.store.appearance.theme',
+        [options]='themeOptions',
         (ngModelChange)='saveConfiguration()',
     )
-        option(*ngFor='let theme of themes', [ngValue]='theme.name') {{theme.name|translate}}
 
 .form-line
     .header

--- a/tabby-settings/src/components/windowSettingsTab.component.ts
+++ b/tabby-settings/src/components/windowSettingsTab.component.ts
@@ -12,6 +12,7 @@ import {
     BaseComponent,
     Screen,
     PlatformService,
+    TranslateService,
 } from 'tabby-core'
 
 
@@ -24,6 +25,7 @@ export class WindowSettingsTabComponent extends BaseComponent {
     screens: Screen[]
     Platform = Platform
     isFluentVibrancySupported = false
+    themeOptions: { value: any, name: string }[] = []
 
     @HostBinding('class.content-box') true
 
@@ -32,12 +34,14 @@ export class WindowSettingsTabComponent extends BaseComponent {
         public hostApp: HostAppService,
         public platform: PlatformService,
         public zone: NgZone,
+        translate: TranslateService,
         @Inject(Theme) public themes: Theme[],
         @Optional() public docking?: DockingService,
     ) {
         super()
 
         this.themes = config.enabledServices(this.themes)
+        this.themeOptions = this.themes.map(theme => ({ value: theme.name, name: translate.instant(theme.name) }))
 
         const dockingService = docking
         if (dockingService) {

--- a/tabby-ssh/src/components/sftpPanel.component.scss
+++ b/tabby-ssh/src/components/sftpPanel.component.scss
@@ -29,6 +29,10 @@
         cursor: pointer;
     }
 
+    a.alert {
+        cursor: pointer;
+    }
+
     .breadcrumb-item:first-child {
         font-weight: bold;
     }

--- a/tabby-ssh/src/components/sftpPanel.component.ts
+++ b/tabby-ssh/src/components/sftpPanel.component.ts
@@ -1,12 +1,17 @@
 import * as C from 'constants'
 import { posix as path } from 'path'
 import { Component, Input, Output, EventEmitter, Inject, Optional } from '@angular/core'
-import { FileUpload, DirectoryUpload, DirectoryDownload, MenuItemOptions, NotificationsService, PlatformService } from 'tabby-core'
+import { ConfigService, FileUpload, DirectoryUpload, DirectoryDownload, MenuItemOptions, NotificationsService, PlatformService } from 'tabby-core'
 import { SFTPSession, SFTPFile } from '../session/sftp'
 import { SSHSession } from '../session/ssh'
 import { SFTPContextMenuItemProvider } from '../api'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { SFTPCreateDirectoryModalComponent } from './sftpCreateDirectoryModal.component'
+
+interface ChannelPool {
+    acquire: () => Promise<SFTPSession>
+    release: (ch: SFTPSession) => void
+}
 
 interface PathSegment {
     name: string
@@ -35,6 +40,7 @@ export class SFTPPanelComponent {
     constructor (
         private ngbModal: NgbModal,
         private notifications: NotificationsService,
+        private config: ConfigService,
         public platform: PlatformService,
         @Optional() @Inject(SFTPContextMenuItemProvider) protected contextMenuProviders: SFTPContextMenuItemProvider[],
     ) {
@@ -204,8 +210,119 @@ export class SFTPPanelComponent {
     }
 
     async upload (): Promise<void> {
+        const savedPath = this.path
         const transfers = await this.platform.startUpload({ multiple: true })
-        await Promise.all(transfers.map(t => this.uploadOne(t)))
+        try {
+            await this.withChannelPool(pool =>
+                this.runConcurrent(pool, transfers, (t, sftp) =>
+                    this.uploadOrSkipCancelled(sftp, path.join(savedPath, t.getName()), t)))
+        } catch (e) {
+            // one failure aborts the queue — mark what never ran so nothing
+            // sits in the transfers menu as "in progress" forever
+            for (const t of transfers) {
+                if (!t.isComplete() && !t.isFailed() && !t.isCancelled()) {
+                    t.cancel()
+                }
+            }
+            this.notifications.error(e.message)
+        }
+        if (this.path === savedPath) {
+            await this.navigate(this.path)
+        }
+    }
+
+    // SFTP round trips (open/close + windowing) dominate on many small files;
+    // several files in flight avoid paying the latency serially. Rules that keep
+    // the fragile engine alive: a channel only supports ONE operation in flight
+    // (russh-sftp#15), so every pooled channel is a dedicated one (never the
+    // shared browsing channel), a channel whose operation failed is never
+    // reused, and closing a channel can starve pending requests on others — so
+    // the pool is shared by all concurrent operations of this panel and torn
+    // down sequentially only when the last one finishes.
+    private poolChannels: SFTPSession[] = []
+    private poolFree: SFTPSession[] = []
+    private poolActiveOps = 0
+
+    private async withChannelPool<R> (fn: (pool: ChannelPool) => Promise<R>): Promise<R> {
+        this.poolActiveOps++
+        const pool: ChannelPool = {
+            acquire: async () => {
+                const existing = this.poolFree.pop()
+                if (existing) {
+                    return existing
+                }
+                const ch = await this.session.openDedicatedSFTP()
+                this.poolChannels.push(ch)
+                return ch
+            },
+            release: ch => {
+                this.poolFree.push(ch)
+            },
+        }
+        try {
+            return await fn(pool)
+        } finally {
+            this.poolActiveOps--
+            if (!this.poolActiveOps) {
+                const channels = this.poolChannels
+                this.poolChannels = []
+                this.poolFree = []
+                for (const ch of channels) {
+                    await ch.close().catch(() => null)
+                }
+            }
+        }
+    }
+
+    private async runConcurrent<T> (pool: ChannelPool, items: T[], fn: (item: T, sftp: SFTPSession) => Promise<void>): Promise<void> {
+        const configured = Math.floor(Number(this.config.store.ssh.sftpConcurrentTransfers))
+        const limit = Math.min(8, Math.max(1, Number.isFinite(configured) ? configured : 1))
+        const queue = [...items]
+        const errors: Error[] = []
+        const workersRan = await Promise.all(Array.from({ length: Math.min(limit, queue.length) }, async () => {
+            const channel = await pool.acquire().catch(() => null)
+            if (!channel) {
+                return false
+            }
+            let channelFailed = false
+            while (queue.length && !errors.length) {
+                try {
+                    await fn(queue.shift()!, channel)
+                } catch (e) {
+                    errors.push(e)
+                    channelFailed = true
+                }
+            }
+            if (!channelFailed) {
+                pool.release(channel)
+            }
+            return true
+        }))
+        if (!workersRan.some(x => x)) {
+            // no extra channels available — degrade to sequential on the shared one
+            while (queue.length && !errors.length) {
+                try {
+                    await fn(queue.shift()!, this.sftp)
+                } catch (e) {
+                    errors.push(e)
+                }
+            }
+        }
+        if (errors.length) {
+            throw errors[0]
+        }
+    }
+
+    // each selected file has its own transfers-menu entry, so the user can cancel
+    // one without meaning to abort the rest of the batch — swallow that one cancel
+    private async uploadOrSkipCancelled (sftp: SFTPSession, remotePath: string, transfer: FileUpload): Promise<void> {
+        try {
+            await sftp.upload(remotePath, transfer)
+        } catch (e) {
+            if (!transfer.isCancelled()) {
+                throw e
+            }
+        }
     }
 
     async uploadFolder (): Promise<void> {
@@ -214,17 +331,40 @@ export class SFTPPanelComponent {
     }
 
     async uploadOneFolder (transfer: DirectoryUpload, accumPath = ''): Promise<void> {
+        try {
+            await this.withChannelPool(pool => this.uploadOneFolderPooled(pool, transfer, accumPath))
+        } catch (e) {
+            this.cancelStrandedUploads(transfer)
+            this.notifications.error(e.message)
+        }
+    }
+
+    // a failure aborts the queue mid-way; anything not yet transferred would
+    // otherwise stay "in progress" in the transfers menu with an open fd
+    private cancelStrandedUploads (transfer: DirectoryUpload): void {
+        for (const t of transfer.getChildrens()) {
+            if (t instanceof DirectoryUpload) {
+                this.cancelStrandedUploads(t)
+            } else if (!t.isComplete() && !t.isFailed() && !t.isCancelled()) {
+                t.cancel()
+            }
+        }
+    }
+
+    private async uploadOneFolderPooled (pool: ChannelPool, transfer: DirectoryUpload, accumPath = ''): Promise<void> {
         const savedPath = this.path
-        for(const t of transfer.getChildrens()) {
+        const children = transfer.getChildrens()
+        const files = children.filter(t => !(t instanceof DirectoryUpload))
+        await this.runConcurrent(pool, files, (t, sftp) =>
+            this.uploadOrSkipCancelled(sftp, path.posix.join(savedPath, accumPath, t.getName()), t as FileUpload))
+        for (const t of children) {
             if (t instanceof DirectoryUpload) {
                 try {
-                    await this.sftp.mkdir(path.posix.join(this.path, accumPath, t.getName()))
+                    await this.sftp.mkdir(path.posix.join(savedPath, accumPath, t.getName()))
                 } catch {
                     // Intentionally ignoring errors from making duplicate dirs.
                 }
-                await this.uploadOneFolder(t, path.posix.join(accumPath, t.getName()))
-            } else {
-                await this.sftp.upload(path.posix.join(this.path, accumPath, t.getName()), t)
+                await this.uploadOneFolderPooled(pool, t, path.posix.join(accumPath, t.getName()))
             }
         }
         if (this.path === savedPath) {
@@ -232,55 +372,122 @@ export class SFTPPanelComponent {
         }
     }
 
-    async uploadOne (transfer: FileUpload): Promise<void> {
-        const savedPath = this.path
-        await this.sftp.upload(path.join(this.path, transfer.getName()), transfer)
-        if (this.path === savedPath) {
-            await this.navigate(this.path)
-        }
-    }
-
-    async download (itemPath: string, mode: number, size: number): Promise<void> {
+    async download (itemPath: string, mode: number, size: number): Promise<boolean> {
         const transfer = await this.platform.startDownload(path.basename(itemPath), mode, size)
         if (!transfer) {
-            return
+            return false
         }
-        this.sftp.download(itemPath, transfer)
+        transfer.setRetryHandler(() => this.download(itemPath, mode, size))
+        this.transferOnOwnChannel(sftp => sftp.download(itemPath, transfer)).catch(e => {
+            // sftp.download already set the terminal state; this is a backstop
+            if (!transfer.isCancelled() && !transfer.isFailed()) {
+                transfer.markFailed(e.message)
+            }
+        })
+        return true
     }
 
-    async downloadFolder (folder: SFTPFile): Promise<void> {
-        try {
-            const transfer = await this.platform.startDownloadDirectory(folder.name, 0)
-            if (!transfer) {
-                return
+    // transfers must not share the browsing channel — a channel dies when two
+    // operations are in flight on it at once (russh-sftp#15)
+    private async transferOnOwnChannel (fn: (sftp: SFTPSession) => Promise<void>): Promise<void> {
+        return this.withChannelPool(async pool => {
+            const channel = await pool.acquire().catch(() => null)
+            await fn(channel ?? this.sftp)
+            if (channel) {
+                pool.release(channel)
             }
+        })
+    }
 
-            // Start background size calculation and download simultaneously
-            const sizeCalculationPromise = this.calculateFolderSizeAndUpdate(folder, transfer)
-            const downloadPromise = this.downloadFolderRecursive(folder, transfer, '')
+    async downloadFolder (folder: SFTPFile): Promise<boolean> {
+        // eslint-disable-next-line @typescript-eslint/init-declarations
+        let startedTransfer: DirectoryDownload|null
+        try {
+            startedTransfer = await this.platform.startDownloadDirectory(folder.name, 0)
+        } catch (error) {
+            this.notifications.error(`Failed to download folder: ${error.message}`)
+            return false
+        }
+        if (!startedTransfer) {
+            return false
+        }
+        const transfer = startedTransfer
 
+        transfer.setRetryHandler(() => this.downloadFolder(folder))
+
+        this.downloadFolderTransfer(folder, transfer).catch(error => {
+            // markFailed also closes the transfer, so every escape route out of
+            // downloadFolderTransfer lands in a terminal state here
+            if (!transfer.isCancelled() && !transfer.isFailed()) {
+                transfer.markFailed(error.message)
+            }
+            if (!transfer.isCancelled()) {
+                this.notifications.error(`Failed to download folder: ${error.message}`)
+            }
+        })
+        return true
+    }
+
+    private async downloadFolderTransfer (folder: SFTPFile, transfer: DirectoryDownload): Promise<void> {
+        await this.withChannelPool(async pool => {
+            // size calculation runs on its own pooled channel when possible,
+            // otherwise first — never concurrently with downloads on one channel
+            let sizeCalculationPromise: Promise<unknown> = Promise.resolve()
+            let sizeChannel: SFTPSession|null = null
             try {
-                await Promise.all([sizeCalculationPromise, downloadPromise])
+                sizeChannel = await pool.acquire()
+            } catch {
+                await this.calculateFolderSizeAndUpdate(folder, transfer, this.sftp)
+                transfer.setSizeCalculated()
+            }
+            if (sizeChannel) {
+                const channel = sizeChannel
+                sizeCalculationPromise = this.calculateFolderSizeAndUpdate(folder, transfer, channel)
+                    .then(() => pool.release(channel))
+                    .finally(() => transfer.setSizeCalculated())
+            }
+            const downloadPromise = this.downloadFolderRecursive(pool, folder, transfer, '')
+
+            // settle BOTH before the pool tears channels down — closing a
+            // channel while another still has requests in flight starves it
+            const [sizeResult, downloadResult] = await Promise.allSettled([sizeCalculationPromise, downloadPromise])
+            try {
+                if (downloadResult.status === 'rejected') {
+                    throw downloadResult.reason
+                }
+                if (sizeResult.status === 'rejected') {
+                    throw sizeResult.reason
+                }
                 transfer.setStatus('')
                 transfer.setCompleted(true)
             } catch (error) {
-                transfer.cancel()
+                if (!transfer.isCancelled()) {
+                    transfer.markFailed(error.message)
+                }
                 throw error
             } finally {
                 transfer.close()
             }
-        } catch (error) {
-            this.notifications.error(`Failed to download folder: ${error.message}`)
-            throw error
-        }
+        })
     }
 
-    private async calculateFolderSizeAndUpdate (folder: SFTPFile, transfer: DirectoryDownload) {
-        let totalSize = 0
-        const items = await this.sftp.readdir(folder.fullPath)
+    private async calculateFolderSizeAndUpdate (folder: SFTPFile, transfer: DirectoryDownload, sftp: SFTPSession, sizeBefore = 0): Promise<number> {
+        // totalSize accumulates across the whole recursion so the published
+        // total only ever grows
+        let totalSize = sizeBefore
+        const items = await sftp.readdir(folder.fullPath)
         for (const item of items) {
+            if (transfer.isCancelled()) {
+                break
+            }
             if (item.isDirectory) {
-                totalSize += await this.calculateFolderSizeAndUpdate(item, transfer)
+                totalSize = await this.calculateFolderSizeAndUpdate(item, transfer, sftp, totalSize)
+            } else if (item.isSymlink) {
+                // mirror the download rules: file targets count, directory targets are skipped
+                const target = await sftp.stat(item.fullPath).catch(() => null)
+                if (target && !target.isDirectory) {
+                    totalSize += target.size
+                }
             } else {
                 totalSize += item.size
             }
@@ -289,24 +496,43 @@ export class SFTPPanelComponent {
         return totalSize
     }
 
-    private async downloadFolderRecursive (folder: SFTPFile, transfer: DirectoryDownload, relativePath: string): Promise<void> {
+    private async downloadFolderRecursive (pool: ChannelPool, folder: SFTPFile, transfer: DirectoryDownload, relativePath: string): Promise<void> {
         const items = await this.sftp.readdir(folder.fullPath)
 
-        for (const item of items) {
+        // Symlinks to files are downloaded as their targets; symlinks to
+        // directories are skipped (following them duplicates trees and can loop)
+        const files = items.filter(item => !item.isDirectory)
+        await this.runConcurrent(pool, files, async (item, sftp) => {
             if (transfer.isCancelled()) {
                 throw new Error('Download cancelled')
             }
-
-            const itemRelativePath = relativePath ? `${relativePath}/${item.name}` : item.name
-
-            transfer.setStatus(itemRelativePath)
-            if (item.isDirectory) {
-                await transfer.createDirectory(itemRelativePath)
-                await this.downloadFolderRecursive(item, transfer, itemRelativePath)
-            } else {
-                const fileDownload = await transfer.createFile(itemRelativePath, item.mode, item.size)
-                await this.sftp.download(item.fullPath, fileDownload)
+            let mode = item.mode
+            let size = item.size
+            if (item.isSymlink) {
+                const target = await sftp.stat(item.fullPath).catch(() => null)
+                if (!target || target.isDirectory) {
+                    return
+                }
+                mode = target.mode
+                size = target.size
             }
+            const itemRelativePath = relativePath ? `${relativePath}/${item.name}` : item.name
+            transfer.setStatus(itemRelativePath)
+            const fileDownload = await transfer.createFile(itemRelativePath, mode, size)
+            await sftp.download(item.fullPath, fileDownload)
+        })
+
+        for (const item of items) {
+            if (!item.isDirectory) {
+                continue
+            }
+            if (transfer.isCancelled()) {
+                throw new Error('Download cancelled')
+            }
+            const itemRelativePath = relativePath ? `${relativePath}/${item.name}` : item.name
+            transfer.setStatus(itemRelativePath)
+            await transfer.createDirectory(itemRelativePath)
+            await this.downloadFolderRecursive(pool, item, transfer, itemRelativePath)
         }
     }
 

--- a/tabby-ssh/src/components/sshProfileSettings.component.pug
+++ b/tabby-ssh/src/components/sshProfileSettings.component.pug
@@ -59,9 +59,10 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
 
             .mb-3(*ngIf='connectionMode === "jumpHost"')
                 label(translate) Jump host
-                select.form-control([(ngModel)]='profile.options.jumpHost')
-                    option([ngValue]='null', translate) Select
-                    option([ngValue]='x.id', *ngFor='let x of jumpHosts') {{getJumpHostLabel(x)}}
+                select-dropdown(
+                    [(ngModel)]='profile.options.jumpHost',
+                    [options]='jumpHostOptions'
+                )
 
 
             .d-flex.w-100(*ngIf='connectionMode === "socksProxy"')

--- a/tabby-ssh/src/components/sshProfileSettings.component.ts
+++ b/tabby-ssh/src/components/sshProfileSettings.component.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, ViewChild } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { firstBy } from 'thenby'
 
-import { FileProvidersService, Platform, HostAppService, PromptModalComponent, PartialProfile, ProfilesService, ProfileSettingsComponent, FullyDefined, ProxifiedConfig } from 'tabby-core'
+import { FileProvidersService, Platform, HostAppService, PromptModalComponent, PartialProfile, ProfilesService, ProfileSettingsComponent, FullyDefined, ProxifiedConfig, TranslateService } from 'tabby-core'
 import { LoginScriptsSettingsComponent } from 'tabby-terminal'
 import { PasswordStorageService } from '../services/passwordStorage.service'
 import { ForwardedPortConfig, SSHAlgorithmType, SSHProfile } from '../api'
@@ -24,6 +25,7 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
     supportedAlgorithms = supportedAlgorithms
     algorithms: Record<string, Record<string, boolean>> = {}
     jumpHosts: PartialProfile<SSHProfile>[]
+    jumpHostOptions: { value: any, name: string }[] = []
     @ViewChild('loginScriptsSettings') loginScriptsSettings: LoginScriptsSettingsComponent|null
 
     constructor (
@@ -32,11 +34,16 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
         private passwordStorage: PasswordStorageService,
         private ngbModal: NgbModal,
         private fileProviders: FileProvidersService,
+        private translate: TranslateService,
     ) { }
 
     async ngOnInit () {
         this.jumpHosts = (await this.profilesService.getProfiles({ includeBuiltin: false })).filter(x => x.type === 'ssh' && x !== this.profile)
         this.jumpHosts.sort(firstBy(x => this.getJumpHostLabel(x)))
+        this.jumpHostOptions = [
+            { value: null, name: this.translate.instant(_('Select')) },
+            ...this.jumpHosts.map(x => ({ value: x.id, name: this.getJumpHostLabel(x) })),
+        ]
 
         for (const k of Object.values(SSHAlgorithmType)) {
             this.algorithms[k] = {}
@@ -103,8 +110,8 @@ export class SSHProfileSettingsComponent implements ProfileSettingsComponent<SSH
     save () {
         for (const k of Object.values(SSHAlgorithmType)) {
             this.profile.options.algorithms[k] = Object.entries(this.algorithms[k])
-                .filter(([_, v]) => !!v)
-                .map(([key, _]) => key)
+                .filter(([, v]) => !!v)
+                .map(([key]) => key)
             if(k !== SSHAlgorithmType.COMPRESSION) { this.profile.options.algorithms[k].sort() }
         }
 

--- a/tabby-ssh/src/components/sshSettingsTab.component.pug
+++ b/tabby-ssh/src/components/sshSettingsTab.component.pug
@@ -16,6 +16,18 @@ h3 SSH
         (ngModelChange)='config.save()',
     )
 
+.form-line
+    .header
+        .title(translate) Concurrent SFTP transfers
+        .description(translate) How many files transfer at once when copying folders or multiple files. Lower this if transfers fail on your server.
+    input.form-control(
+        type='number',
+        min='1',
+        max='8',
+        [(ngModel)]='config.store.ssh.sftpConcurrentTransfers',
+        (ngModelChange)='config.save()',
+    )
+
 .form-line(*ngIf='hostApp.platform === Platform.Windows')
     .header
         .title(translate) WinSCP path

--- a/tabby-ssh/src/components/sshSettingsTab.component.pug
+++ b/tabby-ssh/src/components/sshSettingsTab.component.pug
@@ -31,13 +31,11 @@ h3 SSH
     .header
         .title(translate) Agent type
         .description(translate) Forces a specific SSH agent connection type.
-    select.form-control(
+    select-dropdown(
         [(ngModel)]='config.store.ssh.agentType',
+        [options]='agentTypeOptions',
         (ngModelChange)='config.save()',
     )
-        option(value='auto', translate) Automatic
-        option(value='pageant') Pageant
-        option(value='pipe') Named pipe
 
 .form-line(*ngIf='config.store.ssh.agentType === "pipe"')
     .header

--- a/tabby-ssh/src/components/sshSettingsTab.component.ts
+++ b/tabby-ssh/src/components/sshSettingsTab.component.ts
@@ -1,6 +1,7 @@
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, HostBinding } from '@angular/core'
 import { X11Socket } from '../session/x11'
-import { ConfigService, HostAppService, Platform } from 'tabby-core'
+import { ConfigService, HostAppService, Platform, TranslateService } from 'tabby-core'
 
 /** @hidden */
 @Component({
@@ -9,13 +10,20 @@ import { ConfigService, HostAppService, Platform } from 'tabby-core'
 export class SSHSettingsTabComponent {
     Platform = Platform
     defaultX11Display: string
+    agentTypeOptions: { value: string, name: string }[]
 
     @HostBinding('class.content-box') true
 
     constructor (
         public config: ConfigService,
         public hostApp: HostAppService,
+        translate: TranslateService,
     ) {
+        this.agentTypeOptions = [
+            { value: 'auto', name: translate.instant(_('Automatic')) },
+            { value: 'pageant', name: 'Pageant' },
+            { value: 'pipe', name: 'Named pipe' },
+        ]
         const spec = X11Socket.resolveDisplaySpec()
         if ('path' in spec) {
             this.defaultX11Display = spec.path

--- a/tabby-ssh/src/components/sshTab.component.pug
+++ b/tabby-ssh/src/components/sshTab.component.pug
@@ -3,7 +3,8 @@ terminal-toolbar([tab]='this')
     i.fas.fa-xs.fa-circle.text-danger.me-2(*ngIf='!session || !session.open')
     strong.me-auto(
         style='user-select: text; cursor: text;'
-        onclick='event.stopPropagation()'
+        onclick='event.stopPropagation()',
+        (contextmenu)='copyConnectionString($event)'
     ) {{profile.options.user}}@{{profile.options.host}}:{{profile.options.port}}
 
     .me-2(

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -215,6 +215,15 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
         )).response === 0
     }
 
+    copyConnectionString (event: MouseEvent): void {
+        event.preventDefault()
+        event.stopPropagation()
+        const selection = document.getSelection()?.toString()
+        const text = selection?.length ? selection : `${this.profile.options.user}@${this.profile.options.host}:${this.profile.options.port}`
+        this.platform.setClipboard({ text })
+        this.notifications.notice(this.translate.instant('Copied'))
+    }
+
     async openSFTP (): Promise<void> {
         this.sftpPath = await this.session?.getWorkingDirectory() ?? this.sftpPath
         setTimeout(() => {

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -218,8 +218,12 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
     copyConnectionString (event: MouseEvent): void {
         event.preventDefault()
         event.stopPropagation()
-        const selection = document.getSelection()?.toString()
-        const text = selection?.length ? selection : `${this.profile.options.user}@${this.profile.options.host}:${this.profile.options.port}`
+        // only honor a selection made within the label itself
+        const selection = document.getSelection()
+        const withinLabel = selection?.anchorNode && (event.currentTarget as HTMLElement).contains(selection.anchorNode)
+        const text = withinLabel && selection.toString().length
+            ? selection.toString()
+            : `${this.profile.options.user}@${this.profile.options.host}:${this.profile.options.port}`
         this.platform.setClipboard({ text })
         this.notifications.notice(this.translate.instant('Copied'))
     }

--- a/tabby-ssh/src/config.ts
+++ b/tabby-ssh/src/config.ts
@@ -11,6 +11,7 @@ export class SSHConfigProvider extends ConfigProvider {
             x11Display: null,
             knownHosts: [],
             verifyHostKeys: true,
+            sftpConcurrentTransfers: 2,
         },
         hotkeys: {
             'restart-ssh-session': [],

--- a/tabby-ssh/src/session/sftp.ts
+++ b/tabby-ssh/src/session/sftp.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Subject, Observable } from 'rxjs'
+import { randomBytes } from 'crypto'
 import { posix as posixPath } from 'path'
 import { Injector } from '@angular/core'
 import { FileDownload, FileUpload, Logger, LogService } from 'tabby-core'
@@ -88,6 +89,10 @@ export class SFTPSession {
         return new SFTPFileHandle(handle)
     }
 
+    async close (): Promise<void> {
+        await this.sftp.close()
+    }
+
     async rmdir (p: string): Promise<void> {
         await this.sftp.removeDirectory(p)
     }
@@ -112,43 +117,99 @@ export class SFTPSession {
 
     async upload (path: string, transfer: FileUpload): Promise<void> {
         this.logger.info('Uploading into', path)
-        const tempPath = path + '.tabby-upload'
+        // unpredictable temp name: a fixed suffix is preexisting-file/symlink bait
+        // on shared servers, and two uploads of the same file would collide
+        const tempPath = `${path}.${randomBytes(4).toString('hex')}.tabby-upload`
+        let handle: SFTPFileHandle|null = null
+        let written: Promise<void>|null = null
+        let renaming = false
         try {
-            const handle = await this.open(tempPath, russh.OPEN_WRITE | russh.OPEN_CREATE)
-            while (true) {
-                const chunk = await transfer.read()
-                if (!chunk.length) {
-                    break
-                }
-                await handle.write(chunk)
+            // TRUNCATE in case a crashed upload left a longer temp file behind
+            handle = await this.open(tempPath, russh.OPEN_WRITE | russh.OPEN_CREATE | russh.OPEN_TRUNCATE)
+            // pipeline: read the next chunk from disk while the previous one is in
+            // flight to the server (the source buffer is copied per read)
+            let chunk = await transfer.read()
+            while (chunk.length) {
+                written = handle.write(chunk)
+                // no-op handler: if read() below throws, the in-flight write must
+                // not become an unhandled rejection
+                written.catch(() => null)
+                const next = await transfer.read()
+                await written
+                written = null
+                chunk = next
+            }
+            if (transfer.isCancelled()) {
+                // a cancelled source reads as EOF — don't rename a partial file
+                // over the target
+                throw new Error('Transfer cancelled')
             }
             await handle.close()
+            handle = null
             await this.unlink(path).catch(() => null)
+            renaming = true
             await this.rename(tempPath, path)
             transfer.close()
         } catch (e) {
-            transfer.cancel()
-            this.unlink(tempPath).catch(() => null)
+            if (transfer.isCancelled()) {
+                transfer.cancel()
+            } else {
+                transfer.markFailed(e.message)
+            }
+            // settle the in-flight write, then close before unlink — some
+            // servers refuse to delete open files
+            await written?.catch(() => null)
+            written = null
+            await handle?.close().catch(() => null)
+            handle = null
+            if (!renaming) {
+                await this.unlink(tempPath).catch(() => null)
+            }
+            // if the rename itself failed, the target is already gone — keep the
+            // fully-written temp file instead of destroying the only copy
             throw e
         }
     }
 
     async download (path: string, transfer: FileDownload): Promise<void> {
         this.logger.info('Downloading', path)
+        let handle: SFTPFileHandle|null = null
+        let pending: Promise<Uint8Array>|null = null
         try {
-            const handle = await this.open(path, russh.OPEN_READ)
+            handle = await this.open(path, russh.OPEN_READ)
+            // pipeline: request the next chunk from the server while the previous
+            // one is being written to disk
+            pending = handle.read()
             while (true) {
-                const chunk = await handle.read()
-                if (!chunk.length) {
+                const chunk = await pending
+                if (!chunk.length || transfer.isCancelled()) {
+                    pending = null
                     break
                 }
+                pending = handle.read()
+                // no-op handler: if write() below throws, the in-flight read must
+                // not become an unhandled rejection
+                pending.catch(() => null)
                 await transfer.write(chunk)
             }
+            if (transfer.isCancelled()) {
+                throw new Error('Transfer cancelled')
+            }
             transfer.close()
-            handle.close()
         } catch (e) {
-            transfer.cancel()
+            // a genuine failure must read as "Failed" with its message, not as a
+            // user cancel (which alone reads as EOF and sets isCancelled first)
+            if (transfer.isCancelled()) {
+                transfer.cancel()
+            } else {
+                transfer.markFailed(e.message)
+            }
             throw e
+        } finally {
+            // settle the in-flight read before closing — closing a handle with a
+            // request in flight puts two operations on the channel at once
+            await pending?.catch(() => null)
+            await handle?.close().catch(() => null)
         }
     }
 

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -371,6 +371,15 @@ export class SSHSession {
         return new SFTPSession(this.sftp, this.injector)
     }
 
+    /** Unlike openSFTP(), which hands out wrappers of one shared channel,
+     * this opens a channel the caller owns and must close */
+    async openDedicatedSFTP (): Promise<SFTPSession> {
+        if (!(this.ssh instanceof russh.AuthenticatedSSHClient)) {
+            throw new Error('Cannot open SFTP session before auth')
+        }
+        return new SFTPSession(await this.ssh.activateSFTP(await this.ssh.openSessionChannel()), this.injector)
+    }
+
     async start (): Promise<void> {
         await this.init()
 

--- a/tabby-telnet/src/components/telnetTab.component.ts
+++ b/tabby-telnet/src/components/telnetTab.component.ts
@@ -27,8 +27,19 @@ export class TelnetTabComponent extends ConnectableTerminalTabComponent<TelnetPr
 
     ngOnInit (): void {
         this.subscribeUntilDestroyed(this.hotkeys.hotkey$, hotkey => {
-            if (this.hasFocus && hotkey === 'restart-telnet-session') {
-                this.reconnect()
+            if (!this.hasFocus) {
+                return
+            }
+            switch (hotkey) {
+                case 'restart-telnet-session':
+                    this.reconnect()
+                    break
+                case 'home':
+                    this.sendInput('\x1bOH')
+                    break
+                case 'end':
+                    this.sendInput('\x1bOF')
+                    break
             }
         })
 

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -405,7 +405,12 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             this.alternateScreenActive = x
         })
 
-        setImmediate(async () => {
+        // Defer the heavy frontend init (WebGL context + shader compile, ~100ms of
+        // main-thread work) until the tab-open animation has finished, so it doesn't
+        // drop the animation's frames. Session output is buffered and replayed on
+        // attach, so this adds no perceived shell startup latency.
+        const attachDelay = document.body.classList.contains('no-animations') ? 0 : 160
+        setTimeout(async () => {
             if (this.hasFocus) {
                 await this.frontend?.attach(this.content.nativeElement, this.profile)
                 this.frontend?.configure(this.profile)
@@ -415,7 +420,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     this.frontend?.configure(this.profile)
                 })
             }
-        })
+        }, attachDelay)
 
         this.attachTermContainerHandlers()
 

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -240,7 +240,6 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     if (this.frontend?.getSelection()) {
                         this.frontend.copySelection()
                         this.frontend.clearSelection()
-                        this.notifications.notice(this.translate.instant('Copied'))
                     } else {
                         this.forEachFocusedTerminalPane(tab => tab.sendInput('\x03'))
                     }
@@ -414,10 +413,13 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             if (this.hasFocus) {
                 await this.frontend?.attach(this.content.nativeElement, this.profile)
                 this.frontend?.configure(this.profile)
+                // focus received before attach was a no-op on the unattached terminal
+                this.frontend?.focus()
             } else {
                 this.focused$.pipe(first()).subscribe(async () => {
                     await this.frontend?.attach(this.content.nativeElement, this.profile)
                     this.frontend?.configure(this.profile)
+                    this.frontend?.focus()
                 })
             }
         }, attachDelay)
@@ -537,7 +539,8 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             data = data.replace(/[\r\n]+/g, ' ')
         }
 
-        if (this.config.store.terminal.trimWhitespaceOnPaste && data.indexOf('\n') === data.length - 1) {
+        // all line breaks are '\r' after the conversion above
+        if (this.config.store.terminal.trimWhitespaceOnPaste && data.indexOf('\r') === data.length - 1) {
             // Ends with a newline and has no other line breaks
             data = data.substring(0, data.length - 1)
         }

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -410,23 +410,20 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
         // drop the animation's frames. Session output is buffered and replayed on
         // attach, so this adds no perceived shell startup latency.
         const attachDelay = document.body.classList.contains('no-animations') ? 0 : 160
-        setTimeout(async () => {
+        const attachAndFocus = async () => {
+            await this.frontend?.attach(this.content.nativeElement, this.profile)
+            this.frontend?.configure(this.profile)
+            // focus received before attach was a no-op on the unattached
+            // terminal; check again — it may also have moved during attach
             if (this.hasFocus) {
-                await this.frontend?.attach(this.content.nativeElement, this.profile)
-                this.frontend?.configure(this.profile)
-                // focus received before attach was a no-op on the unattached
-                // terminal; re-check hasFocus — it may have moved during attach
-                if (this.hasFocus) {
-                    this.frontend?.focus()
-                }
+                this.frontend?.focus()
+            }
+        }
+        setTimeout(() => {
+            if (this.hasFocus) {
+                attachAndFocus()
             } else {
-                this.focused$.pipe(first()).subscribe(async () => {
-                    await this.frontend?.attach(this.content.nativeElement, this.profile)
-                    this.frontend?.configure(this.profile)
-                    if (this.hasFocus) {
-                        this.frontend?.focus()
-                    }
-                })
+                this.focused$.pipe(first()).subscribe(attachAndFocus)
             }
         }, attachDelay)
 

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -690,7 +690,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
         }
 
         this.termContainerSubscriptions.subscribe(this.frontend.title$, title => this.zone.run(() => {
-            if (!this.disableDynamicTitle) {
+            if (!this.disableDynamicTitle && this.shouldSetDynamicTitle(title)) {
                 this.setTitle(title)
             }
         }))
@@ -788,6 +788,11 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
 
     @HostBinding('class.with-title-inset') get hasTitleInset (): boolean {
         return this.hostApp.platform === Platform.macOS && this.config.store.appearance.tabsLocation !== 'top' && this.config.store.appearance.frame === 'thin'
+    }
+
+    /** Whether a title reported by the terminal should be applied to the tab */
+    protected shouldSetDynamicTitle (_title: string): boolean {
+        return true
     }
 
     protected attachSessionHandler <T> (observable: Observable<T>, handler: (v: T) => void): void {

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -240,6 +240,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     if (this.frontend?.getSelection()) {
                         this.frontend.copySelection()
                         this.frontend.clearSelection()
+                        this.notifications.notice(this.translate.instant('Copied'))
                     } else {
                         this.forEachFocusedTerminalPane(tab => tab.sendInput('\x03'))
                     }
@@ -413,13 +414,18 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
             if (this.hasFocus) {
                 await this.frontend?.attach(this.content.nativeElement, this.profile)
                 this.frontend?.configure(this.profile)
-                // focus received before attach was a no-op on the unattached terminal
-                this.frontend?.focus()
+                // focus received before attach was a no-op on the unattached
+                // terminal; re-check hasFocus — it may have moved during attach
+                if (this.hasFocus) {
+                    this.frontend?.focus()
+                }
             } else {
                 this.focused$.pipe(first()).subscribe(async () => {
                     await this.frontend?.attach(this.content.nativeElement, this.profile)
                     this.frontend?.configure(this.profile)
-                    this.frontend?.focus()
+                    if (this.hasFocus) {
+                        this.frontend?.focus()
+                    }
                 })
             }
         }, attachDelay)
@@ -530,7 +536,8 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
     async paste (): Promise<void> {
         let data = this.platform.readClipboard()
         if (this.hostApp.platform === Platform.Windows) {
-            data = data.replaceAll('\r\n', '\r')
+            // also handle bare-LF clipboards (git-bash, editors)
+            data = data.replaceAll('\r\n', '\r').replaceAll('\n', '\r')
         } else {
             data = data.replaceAll('\n', '\r')
         }

--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -674,6 +674,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     if (this.frontend?.getSelection()) {
                         this.frontend.copySelection()
                         this.frontend.clearSelection()
+                        this.notifications.notice(this.translate.instant('Copied'))
                     } else {
                         this.paste()
                     }

--- a/tabby-terminal/src/components/inputProcessingSettings.component.pug
+++ b/tabby-terminal/src/components/inputProcessingSettings.component.pug
@@ -2,8 +2,7 @@
     .header
         .title(translate) Backspace key mode
 
-    select.form-control([(ngModel)]='options.backspace')
-        option(
-            *ngFor='let mode of backspaceModes',
-            [value]='mode.key',
-        ) {{mode.name|translate}}
+    select-dropdown(
+        [(ngModel)]='options.backspace',
+        [options]='backspaceModeOptions',
+    )

--- a/tabby-terminal/src/components/inputProcessingSettings.component.ts
+++ b/tabby-terminal/src/components/inputProcessingSettings.component.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, Input } from '@angular/core'
+import { TranslateService } from 'tabby-core'
 import { InputProcessingOptions } from '../middleware/inputProcessing'
 
 /** @hidden */
@@ -29,6 +30,15 @@ export class InputProcessingSettingsComponent {
             name: 'Delete (CSI 3~)',
         },
     ]
+
+    backspaceModeOptions: { value: any, name: string }[] = []
+
+    constructor (translate: TranslateService) {
+        this.backspaceModeOptions = this.backspaceModes.map(mode => ({
+            value: mode.key,
+            name: translate.instant(mode.name),
+        }))
+    }
 
     getBackspaceModeName (key) {
         return this.backspaceModes.find(x => x.key === key)?.name

--- a/tabby-terminal/src/components/searchPanel.component.scss
+++ b/tabby-terminal/src/components/searchPanel.component.scss
@@ -5,10 +5,11 @@
     right: 40px;
     height: 36px;
     z-index: 5;
-    border-radius: 0 0 5px 5px;
-    background: rgba(0, 0, 0, .95);
-    border: 1px solid rgba(0, 0, 0, .5);
+    border-radius: 0 0 .5rem .5rem;
+    background: var(--theme-bg-more, rgba(0, 0, 0, .95));
+    border: 1px solid var(--theme-bg-more-2, rgba(0, 0, 0, .5));
     border-top: 0;
+    box-shadow: 0 .5rem 1.5rem rgba(0, 0, 0, .35);
     display: flex;
 
     button {

--- a/tabby-terminal/src/components/streamProcessingSettings.component.pug
+++ b/tabby-terminal/src/components/streamProcessingSettings.component.pug
@@ -20,10 +20,10 @@
     .header
         .title(translate) Input newlines
 
-    select.form-control(
+    select-dropdown(
         [(ngModel)]='options.inputNewlines',
+        [options]='newlineModeOptions',
     )
-        option([ngValue]='mode.key', *ngFor='let mode of newlineModes') {{mode.name|translate}}
 
 .form-line
     .header
@@ -47,7 +47,7 @@
     .header
         .title(translate) Output newlines
 
-    select.form-control(
+    select-dropdown(
         [(ngModel)]='options.outputNewlines',
+        [options]='newlineModeOptions',
     )
-        option([ngValue]='mode.key', *ngFor='let mode of newlineModes') {{mode.name|translate}}

--- a/tabby-terminal/src/components/streamProcessingSettings.component.ts
+++ b/tabby-terminal/src/components/streamProcessingSettings.component.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, Input } from '@angular/core'
+import { TranslateService } from 'tabby-core'
 import { StreamProcessingOptions } from '../middleware/streamProcessing'
 
 /** @hidden */
@@ -56,6 +57,15 @@ export class StreamProcessingSettingsComponent {
         { key: 'implicit_cr', name: _('Implicit CR in every LF') },
         { key: 'implicit_lf', name: _('Implicit LF in every CR') },
     ]
+
+    newlineModeOptions: { value: any, name: string }[] = []
+
+    constructor (translate: TranslateService) {
+        this.newlineModeOptions = this.newlineModes.map(mode => ({
+            value: mode.key,
+            name: translate.instant(mode.name),
+        }))
+    }
 
     getInputModeName (key) {
         return this.inputModes.find(x => x.key === key)?.name

--- a/tabby-terminal/src/components/terminalSettingsTab.component.pug
+++ b/tabby-terminal/src/components/terminalSettingsTab.component.pug
@@ -156,6 +156,15 @@ div.mt-4
 
     .form-line
         .header
+            .title(translate) Confirm before closing a running tab
+            .description(translate) Ask before closing a terminal that still has a process running
+        toggle(
+            [(ngModel)]='config.store.terminal.warnOnClose',
+            (ngModelChange)='config.save()',
+        )
+
+    .form-line
+        .header
             .title(translate) Replace line breaks with spaces
             .description(translate) Flatten pasted text into a single line for terminals that do not support multiline paste
         toggle(

--- a/tabby-terminal/src/components/terminalSettingsTab.component.pug
+++ b/tabby-terminal/src/components/terminalSettingsTab.component.pug
@@ -6,12 +6,11 @@ div
             .title(translate) Frontend
             .description(translate) Switches terminal frontend implementation (experimental)
 
-        select.form-control(
+        select-dropdown(
             [(ngModel)]='config.store.terminal.frontend',
+            [options]='frontendOptions',
             (ngModelChange)='config.save()',
         )
-            option(value='xterm-webgl') xterm (WebGL)
-            option(value='xterm') xterm (canvas)
 
     .form-line
         .header
@@ -72,14 +71,11 @@ div.mt-4
             .title(translate) Right click
             .description(*ngIf='config.store.terminal.rightClick == "paste"', translate) Long-click for context menu
 
-        select.form-control(
+        select-dropdown(
             [(ngModel)]='config.store.terminal.rightClick',
+            [options]='rightClickOptions',
             (ngModelChange)='config.save()'
         )
-            option(ngValue='off', translate) Off
-            option(ngValue='menu', translate) Context menu
-            option(ngValue='paste', translate) Paste
-            option(ngValue='clipboard', translate) Paste if no selection, else copy
 
     .form-line
         .header
@@ -106,15 +102,11 @@ div.mt-4
             .title(translate) Require a key to click links
             .description(translate) When enabled, links are only clickable while holding this key
 
-        select.form-control(
+        select-dropdown(
             [(ngModel)]='config.store.clickableLinks.modifier',
+            [options]='linkModifierOptions',
             (ngModelChange)='config.save()',
         )
-            option([ngValue]='null', translate) No modifier
-            option(value='ctrlKey', *ngIf='hostApp.platform !== Platform.macOS') Ctrl
-            option(value='altKey') {{altKeyName}}
-            option(value='shiftKey') Shift
-            option(value='metaKey') {{metaKeyName}}
 
 .mt-4
     h3(translate) Clipboard

--- a/tabby-terminal/src/components/terminalSettingsTab.component.pug
+++ b/tabby-terminal/src/components/terminalSettingsTab.component.pug
@@ -63,6 +63,15 @@ div.mt-4
             (ngModelChange)='config.save()',
         )
 
+    .form-line
+        .header
+            .title(translate) Smooth scrolling
+            .description(translate) Animates the terminal scrolling instead of jumping line by line
+        toggle(
+            [(ngModel)]='config.store.terminal.smoothScrolling',
+            (ngModelChange)='config.save()',
+        )
+
 div.mt-4
     h3(translate) Mouse
 

--- a/tabby-terminal/src/components/terminalSettingsTab.component.ts
+++ b/tabby-terminal/src/components/terminalSettingsTab.component.ts
@@ -1,5 +1,6 @@
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import { Component, HostBinding } from '@angular/core'
-import { ConfigService, HostAppService, Platform, PlatformService, altKeyName, metaKeyName } from 'tabby-core'
+import { ConfigService, HostAppService, Platform, PlatformService, TranslateService, altKeyName, metaKeyName } from 'tabby-core'
 
 /** @hidden */
 @Component({
@@ -10,13 +11,39 @@ export class TerminalSettingsTabComponent {
     altKeyName = altKeyName
     metaKeyName = metaKeyName
 
+    frontendOptions = [
+        { value: 'xterm-webgl', name: 'xterm (WebGL)' },
+        { value: 'xterm', name: 'xterm (canvas)' },
+    ]
+
+    rightClickOptions: { value: any, name: string }[] = []
+    linkModifierOptions: { value: any, name: string }[] = []
+
     @HostBinding('class.content-box') true
 
     constructor (
         public config: ConfigService,
         public hostApp: HostAppService,
         private platform: PlatformService,
-    ) { }
+        translate: TranslateService,
+    ) {
+        this.rightClickOptions = [
+            { value: 'off', name: translate.instant(_('Off')) },
+            { value: 'menu', name: translate.instant(_('Context menu')) },
+            { value: 'paste', name: translate.instant(_('Paste')) },
+            { value: 'clipboard', name: translate.instant(_('Paste if no selection, else copy')) },
+        ]
+        this.linkModifierOptions = [
+            { value: null, name: translate.instant(_('No modifier')) },
+            { value: 'ctrlKey', name: 'Ctrl' },
+            { value: 'altKey', name: altKeyName },
+            { value: 'shiftKey', name: 'Shift' },
+            { value: 'metaKey', name: metaKeyName },
+        ]
+        if (hostApp.platform === Platform.macOS) {
+            this.linkModifierOptions = this.linkModifierOptions.filter(x => x.value !== 'ctrlKey')
+        }
+    }
 
     openWSLVolumeMixer (): void {
         this.platform.openPath('sndvol.exe')

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -42,6 +42,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             },
             customColorSchemes: [],
             warnOnMultilinePaste: true,
+            warnOnClose: false,
             searchRegexAlwaysEnabled: false,
             searchOptions: {
                 regex: false,

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -29,6 +29,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             copyOnSelect: false,
             copyAsHTML: true,
             scrollOnInput: true,
+            smoothScrolling: true,
             altIsMeta: false,
             wordSeparator: ' ()[]{}\'"',
             colorScheme: {

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -123,8 +123,11 @@ export class TerminalConfigProvider extends ConfigProvider {
                 copy: [
                     'Ctrl-Shift-C',
                 ],
+                // Ctrl-V matches Windows Terminal; without it the shell receives ^V
+                // and PSReadLine's own paste is slow and mangles CRLF clipboards
                 paste: [
                     'Ctrl-Shift-V',
+                    'Ctrl-V',
                     'Shift-Insert',
                 ],
                 'select-all': ['Ctrl-Shift-A'],

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -176,7 +176,10 @@ export class XTermFrontend extends Frontend {
             this.hotkeysService.pushKeyEvent(name, event)
 
             let ret = true
-            if (this.hotkeysService.matchActiveHotkey(true) !== null) {
+            // consume the keystroke on a partial (multi-chord) OR full hotkey match —
+            // otherwise a bound single-chord combo like Ctrl-V still reaches xterm,
+            // which feeds the raw control char (^V) to the shell alongside the hotkey
+            if (this.hotkeysService.matchActiveHotkey(true) !== null || this.hotkeysService.matchActiveHotkey() !== null) {
                 event.stopPropagation()
                 event.preventDefault()
                 ret = false
@@ -186,6 +189,9 @@ export class XTermFrontend extends Frontend {
 
         this.xterm.attachCustomKeyEventHandler((event: KeyboardEvent) => {
             if (this.hostApp.platform !== Platform.Web) {
+                // combos with a native paste-into-textarea default need an
+                // unconditional preventDefault, the hotkey match below is not
+                // guaranteed mid-keystroke-sequence for them
                 if (
                     event.getModifierState('Meta') && event.key.toLowerCase() === 'v' ||
                     event.key === 'Insert' && event.shiftKey

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -26,6 +26,9 @@ const COLOR_NAMES = [
 // before giving up and letting xterm fall back to its DOM renderer.
 const MAX_WEBGL_RECOVERY_ATTEMPTS = 3
 
+// scroll hotkeys stay with the fullscreen app while the alternate buffer is active
+const ALT_SCREEN_PASSTHROUGH_HOTKEYS = ['scroll-to-top', 'scroll-page-up', 'scroll-up', 'scroll-down', 'scroll-page-down', 'scroll-to-bottom']
+
 class FlowControl {
     private blocked = false
     private blocked$ = new BehaviorSubject<boolean>(false)
@@ -178,8 +181,13 @@ export class XTermFrontend extends Frontend {
             let ret = true
             // consume the keystroke on a partial (multi-chord) OR full hotkey match —
             // otherwise a bound single-chord combo like Ctrl-V still reaches xterm,
-            // which feeds the raw control char (^V) to the shell alongside the hotkey
-            if (this.hotkeysService.matchActiveHotkey(true) !== null || this.hotkeysService.matchActiveHotkey() !== null) {
+            // which feeds the raw control char (^V) to the shell alongside the hotkey.
+            // Scroll hotkeys are exempt in the alternate buffer: there's no scrollback
+            // to act on, and fullscreen apps expect those keys.
+            const matched = this.hotkeysService.matchActiveHotkey(true) ?? this.hotkeysService.matchActiveHotkey()
+            const altScreenPassthrough = ALT_SCREEN_PASSTHROUGH_HOTKEYS.includes(matched ?? '')
+                && this.xterm.buffer.active.type === 'alternate'
+            if (matched !== null && !altScreenPassthrough) {
                 event.stopPropagation()
                 event.preventDefault()
                 ret = false

--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -584,6 +584,8 @@ export class XTermFrontend extends Frontend {
         this.xterm.options.cursorBlink = config.terminal.cursorBlink
         this.xterm.options.macOptionIsMeta = config.terminal.altIsMeta
         this.xterm.options.scrollback = config.terminal.scrollbackLines
+        // gated on the global animations toggle like every other animation
+        this.xterm.options.smoothScrollDuration = config.terminal.smoothScrolling && config.accessibility.animations ? 125 : 0
         this.xterm.options.wordSeparator = config.terminal.wordSeparator
         this.xterm.options.drawBoldTextInBrightColors = config.terminal.drawBoldTextInBrightColors
         this.xterm.options.fontWeight = config.terminal.fontWeight


### PR DESCRIPTION
everything in this pr was written by ai. i am stupid and cant code!

verified everything on windows, looks wayyyyy better now

summary
- custom `select-dropdown` component replacing native `<select>` across settings (themed, animated, supports option groups like optgroup)
- redesigned toggle switches and checkboxes to match
- global ui polish: hover/focus transitions, keyboard-only focus rings, themed links/scrollbars/toasts, shared overlay dimming, smooth tab color fades
- settings sidebar and profile selector share a navigation design
- animations respect the accessibility "enable animations" setting
- unfocused window tab bar tint derived from the actual bar color (works on all schemes)
- visible dropdown item hover (bootstrap default was too subtle on themed menus)
- fixes: restart banner clears when changes are undone, wsl tab title no longer flashes through conpty path, middle-click tab close via auxclick, optional native module load failures tolerated in dev builds, smooth mouse-wheel scrolling
