### PR TITLE
fix: various UI improvements

### DIFF
--- a/tabby-core/src/theme.new.scss
+++ b/tabby-core/src/theme.new.scss
@@ -183,7 +183,7 @@ body {
 
 tab-body {
     terminal-toolbar {
-        background: var(--bs-body-bg);
+        background: transparent;
 
         .btn, .toolbar-pin-button {
             font-weight: bold;

--- a/tabby-settings/src/components/settingsTab.component.pug
+++ b/tabby-settings/src/components/settingsTab.component.pug
@@ -1,7 +1,7 @@
 .content
     ul.nav-pills(ngbNav, #nav='ngbNav', [activeId]='activeTab', orientation='vertical')
         li(ngbNavItem='application')
-            a(ngbNavLink)
+            a(ngbNavLink, draggable='false')
                 i.fas.fa-fw.fa-window-maximize.me-2
                 span(translate) Application
             ng-template(ngbNavContent)
@@ -122,7 +122,7 @@
 
         ng-container(*ngFor='let provider of settingsProviders')
             li(*ngIf='provider.prioritized', [ngbNavItem]='provider.id')
-                a.d-flex.align-items-center(ngbNavLink)
+                a.d-flex.align-items-center(ngbNavLink, draggable='false')
                     i(class='fas fa-fw me-2 fa-{{provider.icon}}')
                     span {{provider.title|translate}}
                 ng-template(ngbNavContent)
@@ -132,14 +132,14 @@
 
         ng-container(*ngFor='let provider of settingsProviders')
             li(*ngIf='!provider.prioritized', [ngbNavItem]='provider.id')
-                a.d-flex.align-items-center(ngbNavLink)
+                a.d-flex.align-items-center(ngbNavLink, draggable='false')
                     i(class='fas fa-fw me-2 fa-{{provider.icon || "puzzle-piece"}}')
                     span {{provider.title|translate}}
                 ng-template(ngbNavContent)
                     settings-tab-body([provider]='provider')
 
         li(ngbNavItem='config-file')
-            a.d-flex.align-items-center(ngbNavLink)
+            a.d-flex.align-items-center(ngbNavLink, draggable='false')
                 i.fas.fa-fw.fa-code.me-2
                 span(translate) Config file
             ng-template.test(ngbNavContent)

--- a/tabby-settings/src/components/settingsTab.component.pug
+++ b/tabby-settings/src/components/settingsTab.component.pug
@@ -180,4 +180,11 @@ button.btn.btn-warning.btn-block(
     *ngIf='config.restartRequested',
     (click)='restartApp()',
     translate
-) Restart the app to apply changes
+)
+    span(translate) Restart the app to apply changes
+    i.fa.fa-times.ms-auto.me-1(
+        (click)='dismissRestartBanner(); $event.stopPropagation()',
+        style='cursor:pointer;opacity:0.6',
+        (mouseenter)='$event.target.style.opacity=1',
+        (mouseleave)='$event.target.style.opacity=0.6'
+    )

--- a/tabby-settings/src/components/settingsTab.component.ts
+++ b/tabby-settings/src/components/settingsTab.component.ts
@@ -92,6 +92,11 @@ export class SettingsTabComponent extends BaseTabComponent {
         this.hostApp.relaunch()
     }
 
+    dismissRestartBanner () {
+        this.config.restartRequested = false
+        ;(this.parent as any)?.removeTab?.(this)
+    }
+
     @debounce(500)
     saveConfiguration (requireRestart?: boolean) {
         this.config.save()

--- a/tabby-terminal/src/colorSchemes.ts
+++ b/tabby-terminal/src/colorSchemes.ts
@@ -27,8 +27,6 @@ export class DefaultColorSchemes extends TerminalColorSchemeProvider {
             '#b7fff9',
             '#ffffff',
         ],
-        selection: undefined,
-        cursorAccent: undefined,
     }
 
     static defaultLightColorScheme: TerminalColorScheme = {
@@ -54,8 +52,6 @@ export class DefaultColorSchemes extends TerminalColorSchemeProvider {
             '#3e999f',
             '#ffffff',
         ],
-        selection: undefined,
-        cursorAccent: undefined,
     }
 
     async getSchemes (): Promise<TerminalColorScheme[]> {

--- a/tabby-terminal/src/components/colorSchemeSettingsTab.component.ts
+++ b/tabby-terminal/src/components/colorSchemeSettingsTab.component.ts
@@ -12,6 +12,11 @@ export class ColorSchemeSettingsTabComponent {
         platform: PlatformService,
         public config: ConfigService,
     ) {
-        this.defaultTab = platform.getTheme()
+        const mode = this.config.store.appearance.colorSchemeMode
+        if (mode === 'dark' || mode === 'light') {
+            this.defaultTab = mode
+        } else {
+            this.defaultTab = platform.getTheme()
+        }
     }
 }

--- a/tabby-terminal/src/components/terminalToolbar.component.scss
+++ b/tabby-terminal/src/components/terminalToolbar.component.scss
@@ -15,6 +15,10 @@
     flex-grow: 1;
     display: flex;
     align-items: center;
+
+    ::ng-deep .cdk-drag-placeholder {
+        display: none !important;
+    }
 }
 
 .drag-handle {


### PR DESCRIPTION
This PR contains several small UI and UX fixes:

- Open the color scheme tab matching the current colorSchemeMode instead of always opening the Light Mode tab.

- Fix the default color scheme being incorrectly shown as "Custom".


- Make the terminal toolbar transparent when using vibrancy.
<img width="999" height="144" alt="image" src="https://github.com/user-attachments/assets/87cc735a-bb50-4565-89e1-9669807af324" />

- Prevent the terminal toolbar layout from breaking while dragging tabs.
<img width="564" height="93" alt="image" src="https://github.com/user-attachments/assets/ffd46478-88e6-47ae-ac99-af244dc9bcd6" />

- Add a close button to the restart notification banner.
<img width="990" height="79" alt="image" src="https://github.com/user-attachments/assets/a2702fdc-15a9-4f75-928e-e596c38d6a59" />

- Disable dragging on navigation links in the Settings page.
<img width="389" height="140" alt="image" src="https://github.com/user-attachments/assets/b76cdd5a-01d5-406c-a440-38925dc384a3" />