### PR TITLE
fix(terminal): expose debug hotkeys in settings for remap/disable

### DIFF
--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -6,6 +6,14 @@ export class TerminalConfigProvider extends ConfigProvider {
     defaults = {
         hotkeys: {
             'copy-current-path': [],
+            'debug-save-state': ['Ctrl-Shift-Alt-1'],
+            'debug-load-state': ['Ctrl-Shift-Alt-2'],
+            'debug-copy-state': ['Ctrl-Shift-Alt-3'],
+            'debug-paste-state': ['Ctrl-Shift-Alt-4'],
+            'debug-save-output': ['Ctrl-Shift-Alt-5'],
+            'debug-load-output': ['Ctrl-Shift-Alt-6'],
+            'debug-copy-output': ['Ctrl-Shift-Alt-7'],
+            'debug-paste-output': ['Ctrl-Shift-Alt-8'],
         },
         terminal: {
             frontend: 'xterm-webgl',

--- a/tabby-terminal/src/features/debug.ts
+++ b/tabby-terminal/src/features/debug.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core'
+import { HotkeysService, PlatformService } from 'tabby-core'
 import { TerminalDecorator } from '../api/decorator'
 import { BaseTerminalTabComponent } from '../api/baseTerminalTab.component'
-import { PlatformService } from 'tabby-core'
 
 /** @hidden */
 @Injectable()
 export class DebugDecorator extends TerminalDecorator {
     constructor (
+        private hotkeys: HotkeysService,
         private platform: PlatformService,
     ) {
         super()
@@ -28,40 +29,37 @@ export class DebugDecorator extends TerminalDecorator {
 
         this.subscribeUntilDetached(terminal, terminal.session?.output$.subscribe(handler))
 
-        terminal.addEventListenerUntilDestroyed(terminal.content.nativeElement, 'keyup', (e: KeyboardEvent) => {
-            // Ctrl-Shift-Alt-1
-            if (e.which === 49 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doSaveState(terminal)
+        this.subscribeUntilDetached(terminal, this.hotkeys.hotkey$.subscribe(hotkey => {
+            if (!terminal.hasFocus) {
+                return
             }
-            // Ctrl-Shift-Alt-2
-            if (e.which === 50 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doLoadState(terminal)
+            switch (hotkey) {
+                case 'debug-save-state':
+                    this.doSaveState(terminal)
+                    break
+                case 'debug-load-state':
+                    void this.doLoadState(terminal)
+                    break
+                case 'debug-copy-state':
+                    void this.doCopyState(terminal)
+                    break
+                case 'debug-paste-state':
+                    void this.doPasteState(terminal)
+                    break
+                case 'debug-save-output':
+                    this.doSaveOutput(sessionOutputBuffer)
+                    break
+                case 'debug-load-output':
+                    void this.doLoadOutput(terminal)
+                    break
+                case 'debug-copy-output':
+                    void this.doCopyOutput(sessionOutputBuffer)
+                    break
+                case 'debug-paste-output':
+                    void this.doPasteOutput(terminal)
+                    break
             }
-            // Ctrl-Shift-Alt-3
-            if (e.which === 51 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doCopyState(terminal)
-            }
-            // Ctrl-Shift-Alt-4
-            if (e.which === 52 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doPasteState(terminal)
-            }
-            // Ctrl-Shift-Alt-5
-            if (e.which === 53 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doSaveOutput(sessionOutputBuffer)
-            }
-            // Ctrl-Shift-Alt-6
-            if (e.which === 54 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doLoadOutput(terminal)
-            }
-            // Ctrl-Shift-Alt-7
-            if (e.which === 55 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doCopyOutput(sessionOutputBuffer)
-            }
-            // Ctrl-Shift-Alt-8
-            if (e.which === 56 && e.ctrlKey && e.shiftKey && e.altKey) {
-                this.doPasteOutput(terminal)
-            }
-        })
+        }))
     }
 
     private async loadFile (): Promise<string|null> {

--- a/tabby-terminal/src/hotkeys.ts
+++ b/tabby-terminal/src/hotkeys.ts
@@ -113,6 +113,38 @@ export class TerminalHotkeyProvider extends HotkeyProvider {
             id: 'disconnect-tab',
             name: this.translate.instant('Disconnect current tab (Serial/Telnet/SSH)'),
         },
+        {
+            id: 'debug-save-state',
+            name: this.translate.instant('Save terminal state (debug)'),
+        },
+        {
+            id: 'debug-load-state',
+            name: this.translate.instant('Load terminal state (debug)'),
+        },
+        {
+            id: 'debug-copy-state',
+            name: this.translate.instant('Copy terminal state (debug)'),
+        },
+        {
+            id: 'debug-paste-state',
+            name: this.translate.instant('Paste terminal state (debug)'),
+        },
+        {
+            id: 'debug-save-output',
+            name: this.translate.instant('Save session output (debug)'),
+        },
+        {
+            id: 'debug-load-output',
+            name: this.translate.instant('Load session output (debug)'),
+        },
+        {
+            id: 'debug-copy-output',
+            name: this.translate.instant('Copy session output (debug)'),
+        },
+        {
+            id: 'debug-paste-output',
+            name: this.translate.instant('Paste session output (debug)'),
+        },
     ]
 
     constructor (private translate: TranslateService) { super() }


### PR DESCRIPTION
## Problem

Hidden debug shortcuts (`Ctrl-Shift-Alt-1` through `8`) were hardcoded in
`DebugDecorator` via a `keyup` listener. They did not appear in Settings →
Hotkeys, so users could not remap or disable them.

This caused real conflicts — e.g. `Ctrl-Shift-Alt-5` opens a save-`output.txt`
dialog while the same chord is used system-wide for another tool (#11400).

## Root cause

`tabby-terminal/src/features/debug.ts` matched modifier+number combinations
directly on the terminal element instead of going through `HotkeysService` and
the config-backed hotkey registry used by every other terminal action.

## Fix

- Register all eight debug actions in `TerminalHotkeyProvider` (e.g.
  `debug-save-output` → “Save session output (debug)”).
- Add config defaults preserving the existing chords (`Ctrl-Shift-Alt-1` … `8`).
- Replace the hardcoded `keyup` handler with a `hotkeys.hotkey$` subscription.

Users can now search “debug” in Hotkeys and clear or remap any binding.
Default behavior is unchanged for configs that have not been edited.

## Testing

- ESLint pass on changed files
- `tabby-terminal` webpack build pass
- Verified hotkey match logic: `Ctrl-Shift-Alt-5` → `debug-save-output`; empty binding disables match
- Electron dev app smoke start (`TABBY_DEV=1`)

Addresses #11400