### PR TITLE
feat(terminal): add option to show tab color on index badge

### DIFF
--- a/tabby-core/src/components/tabHeader.component.pug
+++ b/tabby-core/src/components/tabHeader.component.pug
@@ -1,10 +1,19 @@
-.colorbar([style.background-color]='tab.color', *ngIf='tab.color != null')
+.colorbar([style.background-color]='tab.color', *ngIf='tab.color != null && config.store.terminal.tabColorLocation !== "index"')
 .progressbar([style.width]='progress + "%"', *ngIf='progress != null')
 .activity-indicator(*ngIf='tab.activity$|async')
 .current-tab-indicator
 
-.index(*ngIf='!config.store.terminal.hideTabIndex && hostApp.platform === Platform.macOS', cdkDragHandle) {{index + 1}}
-.index(*ngIf='!config.store.terminal.hideTabIndex && hostApp.platform !== Platform.macOS') {{index + 1}}
+.index(
+    *ngIf='!config.store.terminal.hideTabIndex && hostApp.platform === Platform.macOS',
+    cdkDragHandle,
+    [class.tab-color-badge]='config.store.terminal.tabColorLocation === "index" && tab.color != null',
+    [style.background-color]='config.store.terminal.tabColorLocation === "index" && tab.color != null ? tab.color : null',
+) {{index + 1}}
+.index(
+    *ngIf='!config.store.terminal.hideTabIndex && hostApp.platform !== Platform.macOS',
+    [class.tab-color-badge]='config.store.terminal.tabColorLocation === "index" && tab.color != null',
+    [style.background-color]='config.store.terminal.tabColorLocation === "index" && tab.color != null ? tab.color : null',
+) {{index + 1}}
 
 profile-icon(
     *ngIf='config.store.terminal.showTabProfileIcon && tab.icon',

--- a/tabby-core/src/components/tabHeader.component.scss
+++ b/tabby-core/src/components/tabHeader.component.scss
@@ -41,6 +41,11 @@ $tabs-height: 38px;
         transition: 0.25s all;
         align-self: center;
         margin-top: 1px;
+
+        &.tab-color-badge {
+            color: #fff;
+            text-shadow: 0 0 2px rgba(0, 0, 0, 0.45);
+        }
     }
 
     profile-icon {

--- a/tabby-settings/src/components/windowSettingsTab.component.pug
+++ b/tabby-settings/src/components/windowSettingsTab.component.pug
@@ -360,6 +360,32 @@ h3.mt-4(translate) Tabs
         (ngModelChange)='config.save();',
     )
 
+.form-line(*ngIf='!config.store.terminal.hideTabIndex')
+    .header
+        .title(translate) Tab color indicator
+        .description(translate) Where to show the custom tab color
+    .btn-group
+        input.btn-check(
+            type='radio',
+            name='tabColorLocation',
+            [(ngModel)]='config.store.terminal.tabColorLocation',
+            (ngModelChange)='config.save()',
+            id='tabColorLocationColorbar',
+            value='colorbar',
+        )
+        label.btn.btn-secondary(for='tabColorLocationColorbar')
+            span(translate) Bottom strip
+        input.btn-check(
+            type='radio',
+            name='tabColorLocation',
+            [(ngModel)]='config.store.terminal.tabColorLocation',
+            (ngModelChange)='config.save()',
+            id='tabColorLocationIndex',
+            value='index',
+        )
+        label.btn.btn-secondary(for='tabColorLocationIndex')
+            span(translate) Index badge
+
 .form-line
     .header
         .title(translate) Show profile icon on tab

--- a/tabby-terminal/src/config.ts
+++ b/tabby-terminal/src/config.ts
@@ -21,6 +21,7 @@ export class TerminalConfigProvider extends ConfigProvider {
             cursor: 'block',
             cursorBlink: true,
             hideTabIndex: false,
+            tabColorLocation: 'colorbar',
             showTabProfileIcon: false,
             hideCloseButton: false,
             hideTabOptionsButton: false,


### PR DESCRIPTION
## Problem

When a custom tab color is set, Tabby always shows it as a thin strip at
the bottom of the tab header. Long-time Terminus users preferred the old
style where the color appeared on the numbered tab index badge instead.

## Root cause

`tabHeader.component.pug` always renders `.colorbar` separately from
`.index`, with no setting to choose where the color is displayed.

## Fix

- Add `terminal.tabColorLocation` config (`"colorbar"` | `"index"`),
  defaulting to `"colorbar"` for backward compatibility.
- In `"index"` mode, apply `tab.color` as the index badge background and
  hide the bottom colorbar.
- Add a **Tab color indicator** control under Settings → Window → Tabs
  (hidden when tab index is disabled).
- Style the colored badge with white text and a light shadow for contrast.

## Testing

- `tabby-core` and `tabby-settings` webpack builds pass
- Manual test: set tab color, toggle Bottom strip / Index badge in settings

Addresses #11328