### PR TITLE
fix(settings): guard hotkey config lookup for missing plugin paths

### DIFF
--- a/tabby-settings/src/components/hotkeySettingsTab.component.ts
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.ts
@@ -35,17 +35,14 @@ export class HotkeySettingsTabComponent {
     }
 
     getHotkeys (id: string): Hotkey[] {
-        let ptr: unknown = this.config.store.hotkeys
-        for (const token of id.split(/\./g)) {
-            if (!ptr || typeof ptr !== 'object') {
+        let ptr: any = this.config.store.hotkeys
+        for (const token of id.split('.')) {
+            ptr = ptr?.[token]
+            if (ptr == null) {
                 return []
             }
-            ptr = (ptr as Record<string, unknown>)[token]
         }
-        if (!Array.isArray(ptr)) {
-            return []
-        }
-        return ptr.map(hotkey => this.detectDuplicates(hotkey))
+        return Array.isArray(ptr) ? ptr.map(hotkey => this.detectDuplicates(hotkey)) : []
     }
 
     setHotkeys (id: string, hotkeys: Hotkey[]) {

--- a/tabby-settings/src/components/hotkeySettingsTab.component.ts
+++ b/tabby-settings/src/components/hotkeySettingsTab.component.ts
@@ -35,17 +35,26 @@ export class HotkeySettingsTabComponent {
     }
 
     getHotkeys (id: string): Hotkey[] {
-        let ptr = this.config.store.hotkeys
+        let ptr: unknown = this.config.store.hotkeys
         for (const token of id.split(/\./g)) {
-            ptr = ptr[token]
+            if (!ptr || typeof ptr !== 'object') {
+                return []
+            }
+            ptr = (ptr as Record<string, unknown>)[token]
         }
-        return (ptr || []).map(hotkey => this.detectDuplicates(hotkey))
+        if (!Array.isArray(ptr)) {
+            return []
+        }
+        return ptr.map(hotkey => this.detectDuplicates(hotkey))
     }
 
     setHotkeys (id: string, hotkeys: Hotkey[]) {
-        let ptr = this.config.store
+        let ptr: any = this.config.store
         let prop = 'hotkeys'
         for (const token of id.split(/\./g)) {
+            if (ptr[prop] == null || typeof ptr[prop] !== 'object' || Array.isArray(ptr[prop])) {
+                ptr[prop] = {}
+            }
             ptr = ptr[prop]
             prop = token
         }


### PR DESCRIPTION
## Problem

Opening Settings → Hotkeys can freeze the entire settings UI with:

```
TypeError: Cannot read properties of undefined (reading 'toggle')
```

Once thrown, Angular change detection breaks and the sidebar stops responding.

## Root cause

`HotkeySettingsTabComponent.getHotkeys()` walks dotted hotkey ids
(e.g. from plugins like `command-tips`) through `config.store.hotkeys`
without checking that each path segment exists. A plugin-registered id
whose config branch was never created makes `ptr` undefined on the next
token access.

## Fix

- **`getHotkeys`**: return `[]` when a path segment is missing or the
  resolved value is not an array (covers `__nonStructural` placeholders).
- **`setHotkeys`**: create missing nested objects when the user assigns
  a binding to a hotkey that has no config entry yet.

## Testing

- ESLint pass on changed file
- `tabby-settings` webpack build pass
- Verified lookup logic: missing plugin paths return `[]`, existing keys unchanged

Addresses #11363