### PR TITLE
fix(terminal): reset terminal modes on connectable session destroy

### DIFF
--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -68,6 +68,7 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
         super.onSessionDestroyed()
 
         if (this.frontend) {
+            this.frontend.resetTerminalModes()
             if (this.profile.behaviorOnSessionEnd === 'reconnect' && !this.isDisconnectedByHand) {
                 this.reconnect()
             } else if (this.profile.behaviorOnSessionEnd === 'keep' || !this.shouldTabBeDestroyedOnSessionClose()) {


### PR DESCRIPTION
## Problem

When a connectable session (SSH/telnet/serial) ends abruptly, programs like tmux may have enabled mouse tracking without sending disable sequences. xterm.js can retain stale terminal modes until manually reset.

## Root cause

`resetTerminalModes()` only ran on manual reconnect. It was not called when a connectable session is destroyed on disconnect.

## Fix

Call `resetTerminalModes()` in `onSessionDestroyed` to clear stale mouse tracking and bracketed-paste state when the session ends.

**Limitation:** Does not cover nested SSH where the outer session stays open (#11397). Maintainer feedback: bell-based heuristics would break legitimate TUI bells.

Addresses #11397