### PR TITLE
fix(terminal): refresh profile defaults on reconnect #9834

### DIFF
--- a/tabby-core/src/services/config.service.ts
+++ b/tabby-core/src/services/config.service.ts
@@ -105,6 +105,15 @@ export class ConfigProxy<T extends AnyRec> {
             return deepClone(defaults[key])
         }
 
+        this.__setDefaults = (newDefaults: T) => { // eslint-disable-line @typescript-eslint/unbound-method
+            for (const key in defaults) {
+                if (isStructuralMember(defaults[key]) && isStructuralMember(newDefaults[key])) {
+                    (this as any)[key].__setDefaults(newDefaults[key])
+                }
+            }
+            defaults = newDefaults
+        }
+
         this.__setValue = (key: keyof T, value: any) => { // eslint-disable-line @typescript-eslint/unbound-method
             if (deepEqual(value, this.__getDefault(key))) {
                 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
@@ -131,6 +140,8 @@ export class ConfigProxy<T extends AnyRec> {
     __getValue (_key: keyof T): any { }
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function
     __setValue (_key: keyof T, _value: any) { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    __setDefaults (_defaults: T): void { }
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function
     __getDefault (_key: keyof T): any { }
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-empty-function

--- a/tabby-core/src/services/profiles.service.ts
+++ b/tabby-core/src/services/profiles.service.ts
@@ -71,6 +71,14 @@ export class ProfilesService {
         return new ConfigProxy(profile, defaults) as any
     }
 
+    refreshConfigProxyForProfile <T extends Profile> (profile: FullyDefined<T>): FullyDefined<T> {
+        if (profile instanceof ConfigProxy) {
+            const defaults = this.getProfileDefaults(profile).reduce(configMerge, {})
+            profile.__setDefaults(defaults)
+        }
+        return profile
+    }
+
     /**
     * Return an Array of Profiles
     * arg: includeBuiltin (default: true) -> include BuiltinProfiles

--- a/tabby-terminal/src/api/connectableTerminalTab.component.ts
+++ b/tabby-terminal/src/api/connectableTerminalTab.component.ts
@@ -6,7 +6,7 @@ import { first } from 'rxjs'
 
 import { ConnectableTerminalProfile } from './interfaces'
 import { BaseTerminalTabComponent } from './baseTerminalTab.component'
-import { GetRecoveryTokenOptions, RecoveryToken } from 'tabby-core'
+import { GetRecoveryTokenOptions, ProfilesService, RecoveryToken } from 'tabby-core'
 
 
 /**
@@ -118,6 +118,7 @@ export abstract class ConnectableTerminalTabComponent<P extends ConnectableTermi
     async reconnect (): Promise<void> {
         this.session?.destroy()
         this.frontend?.resetTerminalModes()
+        this.profile = this.injector.get(ProfilesService).refreshConfigProxyForProfile(this.profile)
         await this.initializeSession()
         this.clearServiceMessagesOnConnect()
         this.session?.releaseInitialDataBuffer()


### PR DESCRIPTION
## Description
 Fixes #9834.

  `ConfigProxy` captures the merged profile defaults when a terminal tab is created. If the global or group profile defaults are changed while the tab remains open, reconnecting the tab continues to use the stale defaults.

  This is particularly visible with `clearServiceMessagesOnConnect`: when `false` matches the new inherited default, the explicit profile value is removed during config cleanup. The existing proxy then falls back to its
  original default value of `true`, causing the terminal to be cleared after reconnecting.

  This change:

  - Adds support for updating the defaults held by an existing `ConfigProxy`.
  - Recomputes profile defaults using the existing provider, global, and group precedence.
  - Refreshes the profile defaults before initializing a reconnecting session.
  - Keeps explicitly configured profile values higher priority than inherited defaults.
  - Applies the updated defaults only at the reconnect boundary, avoiding live changes to an active connection.

  ## Verification

  - ESLint passed for all modified files.
  - `yarn build:typings` passed for all plugins.
  - `yarn build` completed successfully.
  - `git diff --check` passed.

  Verified on Windows using the Release build.


  ## AI Usage

  Choose the level of AI involvement for this PR.

  * [ ] Fully vibe coded
  * [x] AI-designed, AI-coded, manually checked
  * [ ] Human-designed, AI-coded
  * [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

  *<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*