### PR TITLE
Fix chained public key and keyboard-interactive authentication

### DIFF
--- a/tabby-ssh/package.json
+++ b/tabby-ssh/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "webpack --progress --color",
     "watch": "webpack --progress --color --watch",
+    "test": "node --experimental-default-type=module test/authMethodSelection.test.ts",
     "postinstall": "run-script-os",
     "postinstall:darwin:linux": "exit"
   },

--- a/tabby-ssh/src/session/authMethodSelection.ts
+++ b/tabby-ssh/src/session/authMethodSelection.ts
@@ -1,0 +1,43 @@
+export interface AuthenticationFailure {
+    partialSuccess?: boolean
+    remainingMethods: string[]
+}
+
+export interface AuthenticationPlan<T> {
+    remainingMethods: T[]
+    allowedMethods: string[]
+}
+
+export function selectNextAuthMethod<T> (
+    remainingMethods: readonly T[],
+    allowedMethods: readonly string[],
+    getAuthType: (method: T) => string,
+): T|undefined {
+    return remainingMethods.find(method => allowedMethods.includes(getAuthType(method)))
+}
+
+export function updateAuthPlanAfterFailure<T> (
+    remainingMethods: readonly T[],
+    failure: AuthenticationFailure,
+    getAuthType: (method: T) => string,
+    createPartialSuccessFallback: (authType: string) => T|null,
+): AuthenticationPlan<T> {
+    const updatedRemainingMethods = [...remainingMethods]
+    const updatedAllowedMethods = [...failure.remainingMethods]
+
+    if (failure.partialSuccess) {
+        for (const authType of updatedAllowedMethods) {
+            if (!updatedRemainingMethods.some(method => getAuthType(method) === authType)) {
+                const fallback = createPartialSuccessFallback(authType)
+                if (fallback) {
+                    updatedRemainingMethods.push(fallback)
+                }
+            }
+        }
+    }
+
+    return {
+        remainingMethods: updatedRemainingMethods,
+        allowedMethods: updatedAllowedMethods,
+    }
+}

--- a/tabby-ssh/src/session/ssh.ts
+++ b/tabby-ssh/src/session/ssh.ts
@@ -17,6 +17,7 @@ import { ForwardedPort } from './forwards'
 import { X11Socket } from './x11'
 import { supportedAlgorithms } from '../algorithms'
 import * as russh from 'russh'
+import { selectNextAuthMethod, updateAuthPlanAfterFailure } from './authMethodSelection'
 
 const WINDOWS_OPENSSH_AGENT_PIPE = '\\\\.\\pipe\\openssh-ssh-agent'
 
@@ -652,15 +653,19 @@ export class SSHSession {
         let remainingMethods = [...this.allAuthMethods]
         let methodsLeft = noneResult.remainingMethods
 
-        function maybeSetRemainingMethods (r: russh.AuthFailure) {
-            if (r.remainingMethods.length) {
-                methodsLeft = r.remainingMethods
-            }
+        const updateAuthPlan = (failure: russh.AuthFailure) => {
+            const plan = updateAuthPlanAfterFailure(
+                remainingMethods,
+                failure,
+                sshAuthTypeForMethod,
+                (authType): AuthMethod|null => authType === 'keyboard-interactive' ? { type: 'keyboard-interactive' } : null,
+            )
+            remainingMethods = plan.remainingMethods
+            methodsLeft = plan.allowedMethods
         }
 
         while (true) {
-            const m = methodsLeft
-            const method = remainingMethods.find(x => m.length === 0 || m.includes(sshAuthTypeForMethod(x)))
+            const method = selectNextAuthMethod(remainingMethods, methodsLeft, sshAuthTypeForMethod)
 
             if (this.previouslyDisconnected || !method) {
                 return null
@@ -674,7 +679,7 @@ export class SSHSession {
                 if (result instanceof russh.AuthenticatedSSHClient) {
                     return result
                 }
-                maybeSetRemainingMethods(result)
+                updateAuthPlan(result)
             }
             if (method.type === 'prompt-password') {
                 const modal = this.ngbModal.open(PromptModalComponent)
@@ -696,7 +701,7 @@ export class SSHSession {
                         if (result instanceof russh.AuthenticatedSSHClient) {
                             return result
                         }
-                        maybeSetRemainingMethods(result)
+                        updateAuthPlan(result)
                     } else {
                         continue
                     }
@@ -712,7 +717,7 @@ export class SSHSession {
                     if (result instanceof russh.AuthenticatedSSHClient) {
                         return result
                     }
-                    maybeSetRemainingMethods(result)
+                    updateAuthPlan(result)
                 } catch (e) {
                     this.emitServiceMessage(colors.bgYellow.yellow.black(' ! ') + ` Failed to load private key ${method.name}: ${e}`)
                     continue
@@ -723,7 +728,7 @@ export class SSHSession {
 
                 while (true) {
                     if (state.state === 'failure') {
-                        maybeSetRemainingMethods(state)
+                        updateAuthPlan(state)
                         break
                     }
 
@@ -772,7 +777,7 @@ export class SSHSession {
                     if (result instanceof russh.AuthenticatedSSHClient) {
                         return result
                     }
-                    maybeSetRemainingMethods(result)
+                    updateAuthPlan(result)
                 } catch (e) {
                     const identitySuffix = method.publicKey ? ` with identity ${method.publicKey.fingerprint()}` : ''
                     this.emitServiceMessage(colors.bgYellow.yellow.black(' ! ') + ` Failed to authenticate using agent${identitySuffix}: ${e}`)

--- a/tabby-ssh/test/authMethodSelection.test.ts
+++ b/tabby-ssh/test/authMethodSelection.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { selectNextAuthMethod, updateAuthPlanAfterFailure } from '../src/session/authMethodSelection.ts'
+
+interface Method {
+    type: 'keyboard-interactive'|'password'|'publickey'
+}
+
+const authType = (method: Method): string => method.type
+
+const createPartialSuccessFallback = (type: string): Method|null => {
+    if (type === 'keyboard-interactive') {
+        return { type }
+    }
+    return null
+}
+
+test('continues with keyboard-interactive after partial public-key success', () => {
+    let remainingMethods: Method[] = [{ type: 'publickey' }]
+    let allowedMethods = ['publickey']
+
+    const publicKey = selectNextAuthMethod(remainingMethods, allowedMethods, authType)
+    assert.equal(publicKey?.type, 'publickey')
+    remainingMethods = remainingMethods.filter(method => method !== publicKey)
+
+    const plan = updateAuthPlanAfterFailure(
+        remainingMethods,
+        {
+            partialSuccess: true,
+            remainingMethods: ['keyboard-interactive'],
+        },
+        authType,
+        createPartialSuccessFallback,
+    )
+    allowedMethods = plan.allowedMethods
+
+    assert.equal(selectNextAuthMethod(plan.remainingMethods, allowedMethods, authType)?.type, 'keyboard-interactive')
+})
+
+test('does not add keyboard-interactive after a full public-key rejection', () => {
+    const plan = updateAuthPlanAfterFailure(
+        [],
+        {
+            partialSuccess: false,
+            remainingMethods: ['keyboard-interactive'],
+        },
+        authType,
+        createPartialSuccessFallback,
+    )
+
+    assert.equal(selectNextAuthMethod(plan.remainingMethods, plan.allowedMethods, authType), undefined)
+})
+
+test('selects public-key for a public-key-only server', () => {
+    const method = selectNextAuthMethod<Method>(
+        [{ type: 'publickey' }, { type: 'keyboard-interactive' }],
+        ['publickey'],
+        authType,
+    )
+
+    assert.equal(method?.type, 'publickey')
+})
+
+test('selects keyboard-interactive when it is the only advertised method', () => {
+    const method = selectNextAuthMethod<Method>(
+        [{ type: 'publickey' }, { type: 'keyboard-interactive' }],
+        ['keyboard-interactive'],
+        authType,
+    )
+
+    assert.equal(method?.type, 'keyboard-interactive')
+})
+
+test('selects only methods advertised by the server', () => {
+    const method = selectNextAuthMethod<Method>(
+        [{ type: 'password' }, { type: 'publickey' }, { type: 'keyboard-interactive' }],
+        ['keyboard-interactive'],
+        authType,
+    )
+
+    assert.equal(method?.type, 'keyboard-interactive')
+})
+
+test('stops when the server advertises no remaining methods', () => {
+    const plan = updateAuthPlanAfterFailure(
+        [{ type: 'publickey' }] satisfies Method[],
+        {
+            partialSuccess: false,
+            remainingMethods: [],
+        },
+        authType,
+        createPartialSuccessFallback,
+    )
+
+    assert.deepEqual(plan.allowedMethods, [])
+    assert.equal(selectNextAuthMethod(plan.remainingMethods, plan.allowedMethods, authType), undefined)
+})

--- a/tabby-ssh/tsconfig.json
+++ b/tabby-ssh/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "exclude": ["node_modules", "dist", "typings"],
+  "exclude": ["node_modules", "dist", "typings", "test"],
   "compilerOptions": {
     "baseUrl": "src"
   }

--- a/tabby-ssh/tsconfig.typings.json
+++ b/tabby-ssh/tsconfig.typings.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "exclude": ["node_modules", "dist", "typings"],
+  "exclude": ["node_modules", "dist", "typings", "test"],
   "compilerOptions": {
     "baseUrl": "src",
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## Description

Fixes #10425.

When a profile explicitly selected public-key authentication, its local auth
queue did not contain a keyboard-interactive method. If the server accepted the
key as the first factor and returned partial success with only
`keyboard-interactive` remaining, Tabby stopped instead of showing the MFA
prompt.

This change:

* follows the server's remaining-method list after every failed or partial auth
  response;
* adds keyboard-interactive as a continuation only after partial success and
  only when the server advertises it;
* treats an empty remaining-method list as terminal instead of allowing any
  local method;
* adds regression coverage for chained auth, single-method auth, rejected keys,
  server method filtering, and empty method lists.

Validation:

* `yarn --cwd tabby-ssh test`
* ESLint over `tabby-ssh/src` and `tabby-ssh/test`
* full `yarn run build`
* Windows x64 portable and NSIS packaging
* local OpenSSH `publickey,keyboard-interactive:pam` TOTP fixture using Tabby's
  bundled `russh`
* manual connection to an OpenSSH server requiring public key plus TOTP

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
