### PR TITLE
Fix window title not syncing with renamed tabs

### DIFF
--- a/tabby-core/src/services/app.service.ts
+++ b/tabby-core/src/services/app.service.ts
@@ -238,7 +238,7 @@ export class AppService {
             this._activeTab?.emitFocused()
             this._activeTab?.emitVisibility(true)
         })
-        this.hostWindow.setTitle(this._activeTab?.title)
+        this.hostWindow.setTitle(this._activeTab?.customTitle || this._activeTab?.title)
     }
 
     getParentTab (tab: BaseTabComponent): SplitTabComponent|null {
@@ -399,6 +399,9 @@ export class AppService {
         modal.result.then(result => {
             tab.setTitle(result)
             tab.customTitle = result
+            if (tab === this._activeTab) {
+                this.hostWindow.setTitle(tab.customTitle || tab.title)
+            }
             this.emitTabsChanged()
         }).catch(() => null)
     }

--- a/tabby-core/src/services/app.service.ts
+++ b/tabby-core/src/services/app.service.ts
@@ -238,7 +238,9 @@ export class AppService {
             this._activeTab?.emitFocused()
             this._activeTab?.emitVisibility(true)
         })
-        this.hostWindow.setTitle(this._activeTab?.customTitle || this._activeTab?.title)
+        if (this._activeTab) {
+            this.hostWindow.setTitle(this._activeTab.customTitle || this._activeTab.title)
+        }
     }
 
     getParentTab (tab: BaseTabComponent): SplitTabComponent|null {


### PR DESCRIPTION
## Summary

When renaming a tab, the new custom title was reflected in the tab header but **not** in the window title. The window title reverted to the default/terminal title as soon as the user switched between tabs.

## Root cause

The window title was bound to the active tab's `title` field. For terminal tabs, the terminal continuously overwrites `title` with its own title sequence (current directory, running command, etc.), while the user's chosen name is stored in `customTitle`. The tab header correctly resolves this as `customTitle || title`, but the window title in `selectTab` used `tab.title` directly, so it always showed the underlying terminal title once a tab switch occurred.

Additionally, renaming the currently active tab did not re-sync the window title immediately, because `BaseTabComponent.setTitle` only emits `titleChange` when no `customTitle` is set.

## Changes

In `tabby-core/src/services/app.service.ts`:

- `selectTab` now resolves the window title as `customTitle || title`, matching the tab header.
- `renameTab` now re-syncs the window title immediately when the renamed tab is the active one.

This keeps the window title in sync with the tab header across renames and tab switches.

Fixes #11489