### PR TITLE
fix(terminal): allow Fcitx5 to handle punctuation

### DIFF
--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -22,6 +22,21 @@ const COLOR_NAMES = [
     'brightBlack', 'brightRed', 'brightGreen', 'brightYellow', 'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite',
 ]
 
+// Fcitx5 applies Chinese punctuation during the browser's default text-input
+// processing. If xterm handles these keys on keydown, it calls preventDefault()
+// before Fcitx5 can emit the converted keypress/input event.
+const LINUX_IME_TEXT_KEY_CODES = new Set([
+    'Backquote',
+    'Backslash',
+    'BracketLeft',
+    'BracketRight',
+    'Comma',
+    'Period',
+    'Quote',
+    'Semicolon',
+    'Slash',
+])
+
 // How many times to recreate the WebGL renderer after a lost GPU context
 // before giving up and letting xterm fall back to its DOM renderer.
 const MAX_WEBGL_RECOVERY_ATTEMPTS = 3
@@ -185,6 +200,23 @@ export class XTermFrontend extends Frontend {
         }
 
         this.xterm.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+            if (
+                this.hostApp.platform === Platform.Linux &&
+                event.type === 'keydown' &&
+                !event.ctrlKey &&
+                !event.altKey &&
+                !event.metaKey &&
+                (
+                    LINUX_IME_TEXT_KEY_CODES.has(event.code) ||
+                    event.code === 'Space' && event.shiftKey
+                )
+            ) {
+                // Returning false keeps xterm from sending/cancelling keydown.
+                // The resulting keypress/input event contains either the IME
+                // commit string or the original character when IME is inactive.
+                return false
+            }
+
             if (this.hostApp.platform !== Platform.Web) {
                 if (
                     event.getModifierState('Meta') && event.key.toLowerCase() === 'v' ||


### PR DESCRIPTION
## Description

Fixes Fcitx5 Chinese punctuation input in the xterm terminal on Linux.

xterm handles printable keys during `keydown` and calls `preventDefault()`. This prevents Fcitx5 from completing its normal text-input processing, so Chinese punctuation such as `，。；：`
is sent to the PTY as ASCII punctuation instead.

This change defers punctuation keys and `Shift+Space` to the subsequent `keypress`/`input` event on Linux. As a result:

- Fcitx5 can emit the converted Chinese punctuation.
- `Shift+Space` can be handled by Fcitx5.
- When the IME is inactive, the original ASCII character is still sent.
- Ctrl/Alt/Meta shortcuts retain the existing behavior.
- Other platforms are unaffected.

Related to #11013, which reports a similar keydown/IME interaction on macOS.
This PR is Linux-specific and does not claim to fix the macOS issue.

### Testing

Tested on:

- Ubuntu 22.04
- X11
- Fcitx5
- Tabby terminal using xterm

Manually verified with a physical keyboard:

- `，。；：` are emitted as Chinese punctuation.
- Punctuation remains ASCII when the IME is inactive.
- `Shift+Space` is passed to Fcitx5.
- Modifier-based terminal shortcuts continue through the existing keydown path.

The change also passes the targeted ESLint check and `git diff --check`.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)