### PR TITLE
feat(ssh): option to reopen duplicated/restored tabs in the last working directory

### DIFF
--- a/tabby-ssh/src/api/interfaces.ts
+++ b/tabby-ssh/src/api/interfaces.ts
@@ -37,6 +37,8 @@ export interface SSHProfileOptions extends LoginScriptsOptions {
     httpProxyPort: number | null
     reuseSession: boolean
     input: InputProcessingOptions,
+    cwd: string | null
+    rememberCwd: boolean
 }
 
 export enum PortForwardType {

--- a/tabby-ssh/src/components/sshProfileSettings.component.pug
+++ b/tabby-ssh/src/components/sshProfileSettings.component.pug
@@ -230,6 +230,12 @@ ul.nav-tabs(ngbNav, #nav='ngbNav')
 
             .form-line
                 .header
+                    .title(translate) Remember current directory
+                    .description(translate) Duplicated and restored tabs will start in the last working directory, if the remote shell is set up to report it (see the "Shell working directory reporting" wiki page)
+                toggle([(ngModel)]='profile.options.rememberCwd')
+
+            .form-line
+                .header
                     .title(translate) Keep Alive Interval (Milliseconds)
                 input.form-control(
                     type='number',

--- a/tabby-ssh/src/components/sshTab.component.ts
+++ b/tabby-ssh/src/components/sshTab.component.ts
@@ -3,7 +3,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker'
 import colors from 'ansi-colors'
 import { Component, Injector, HostListener } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { Platform, ProfilesService } from 'tabby-core'
+import { GetRecoveryTokenOptions, Platform, ProfilesService, RecoveryToken } from 'tabby-core'
 import { BaseTerminalTabComponent, ConnectableTerminalTabComponent } from 'tabby-terminal'
 import { SSHService } from '../services/ssh.service'
 import { KeyboardInteractivePrompt, SSHSession } from '../session/ssh'
@@ -187,6 +187,23 @@ export class SSHTabComponent extends ConnectableTerminalTabComponent<SSHProfile>
                 return
             }
         }
+    }
+
+    async getRecoveryToken (options?: GetRecoveryTokenOptions): Promise<RecoveryToken> {
+        const token = await super.getRecoveryToken(options)
+        if (this.profile.options.rememberCwd) {
+            const cwd = await this.session?.getWorkingDirectory() ?? this.profile.options.cwd
+            if (cwd) {
+                token.profile = {
+                    ...token.profile,
+                    options: {
+                        ...token.profile.options,
+                        cwd,
+                    },
+                }
+            }
+        }
+        return token
     }
 
     showPortForwarding (): void {

--- a/tabby-ssh/src/profiles.ts
+++ b/tabby-ssh/src/profiles.ts
@@ -44,6 +44,8 @@ export class SSHProfilesService extends QuickConnectProfileProvider<SSHProfile> 
             httpProxyPort: null,
             reuseSession: true,
             input: { backspace: 'backspace' },
+            cwd: null,
+            rememberCwd: false,
         },
         clearServiceMessagesOnConnect: true,
     }

--- a/tabby-ssh/src/session/shell.ts
+++ b/tabby-ssh/src/session/shell.ts
@@ -53,6 +53,10 @@ export class SSHShellSession extends BaseSession {
 
         this.loginScriptProcessor?.executeUnconditionalScripts()
 
+        if (this.profile.options.cwd) {
+            this.changeInitialDirectory(this.profile.options.cwd)
+        }
+
         this.shell.data$.subscribe(data => {
             this.emitOutput(Buffer.from(data))
         })
@@ -104,6 +108,11 @@ export class SSHShellSession extends BaseSession {
 
     async gracefullyKillProcess (): Promise<void> {
         this.kill('TERM')
+    }
+
+    private changeInitialDirectory (dir: string): void {
+        // The leading space keeps the command out of shell history on shells with HISTCONTROL=ignorespace
+        this.write(Buffer.from(` cd -- '${dir.replace(/'/g, `'\\''`)}'\n`))
     }
 
     supportsWorkingDirectory (): boolean {


### PR DESCRIPTION
## Description

Adds an opt-in **"Remember current directory"** toggle to SSH profiles (Advanced tab).
When enabled, duplicating an SSH tab or restoring tabs after an app restart reopens
the session in the last working directory.

Implements #11493.

**How it works**
- *Capture:* `SSHTabComponent.getRecoveryToken()` stores the session's working
  directory (as already reported via OSC 1337 `CurrentDir`) into the recovery
  token's profile options — mirroring what local terminal tabs already do in
  `tabby-local`.
- *Restore:* when a shell opens with `options.cwd` set, the session writes a
  single ` cd -- '<dir>'` (leading space keeps it out of history; quotes escaped).

**Scope / safety**
- Off by default — with the toggle off, `getRecoveryToken()` falls through to
  `super` and nothing is ever written to the shell.
- If the remote shell doesn't report its cwd, the toggle degrades gracefully to
  today's behavior; the setting's description points at the
  "Shell working directory reporting" wiki page.
- If the remembered directory no longer exists, the shell just prints a normal
  `cd` error and stays in `$HOME`.

Verified: tsc typecheck across the plugin chain, eslint clean, webpack build,
plus manual end-to-end test (duplicate + restart-restore over SSH).

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

