### PR TITLE
fix(terminal): send Ctrl-U for delete-line hotkey

### DIFF
--- a/tabby-terminal/src/api/baseTerminalTab.component.ts
+++ b/tabby-terminal/src/api/baseTerminalTab.component.ts
@@ -288,7 +288,7 @@ export class BaseTerminalTabComponent<P extends BaseTerminalProfile> extends Bas
                     break
                 case 'delete-line':
                     this.forEachFocusedTerminalPane(tab => {
-                        tab.sendInput('\x1bw')
+                        tab.sendInput('\x15')
                     })
                     break
                 case 'delete-previous-word':


### PR DESCRIPTION
## Description

The `delete-line` hotkey currently sends `Esc+w` (`Meta-W`). This maps to `copy-region-as-kill` in zsh and is unbound in fish, so `Cmd+Backspace` does not perform line deletion in common shells.

Send `Ctrl+U` instead, matching the usual line-discard/backward-kill-line behavior.

Related to #9501.

## Testing

- `mise exec node@22 -- node_modules/.bin/eslint tabby-terminal/src/api/baseTerminalTab.component.ts`
- `mise exec node@22 -- npx --yes yarn@1.22.22 run build`
- Built and launched the macOS ARM64 app locally

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
