### PR TITLE
fix(electron): guard window opacity and traffic-light IPC against closed windows

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -466,12 +466,12 @@ export class Window {
         this.window.on('move', onBoundsChange)
         this.window.on('resize', onBoundsChange)
 
-        ipcMain.on('window-set-traffic-light-position', (_event, x, y) => {
-            this.window.setWindowButtonPosition({ x, y })
+        this.on('window-set-traffic-light-position', (_event, x, y) => {
+            this.window?.setWindowButtonPosition({ x, y })
         })
 
-        ipcMain.on('window-set-opacity', (_event, opacity) => {
-            this.window.setOpacity(opacity)
+        this.on('window-set-opacity', (_event, opacity) => {
+            this.window?.setOpacity(opacity)
         })
 
         this.on('window-set-progress-bar', (_, value) => {


### PR DESCRIPTION
## Description

`window-set-traffic-light-position` and `window-set-opacity` are registered with a bare `ipcMain.on`, so every `Window` instance responds to the message regardless of which window sent it, and without checking that its `BrowserWindow` still exists.

Once a window is closed (`this.window` is set to `null`) its handlers stay registered. The next time any window sends one of these messages, the closed window's handler runs and throws:

```
TypeError: Cannot read properties of null (reading 'setWindowButtonPosition')
TypeError: Cannot read properties of null (reading 'setOpacity')
```

This is easy to reproduce by opening and closing windows in quick succession.

Both handlers now go through the existing `on()` helper, which scopes them to the sending window (`e.sender === this.window.webContents`) like the neighbouring `window-set-progress-bar` handler, plus a null check via optional chaining. As a side effect this also stops a `set-opacity` / `set-traffic-light-position` sent by one window from being applied to every open window.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
