### PR TITLE
fix(core): keep window title in sync with renamed tabs

### DIFF
--- a/tabby-core/src/components/baseTab.component.ts
+++ b/tabby-core/src/components/baseTab.component.ts
@@ -112,10 +112,11 @@ export abstract class BaseTabComponent extends BaseComponent {
     }
 
     setTitle (title: string): void {
-        this.title = title
-        if (!this.customTitle) {
-            this.titleChange.next(title)
+        if (this.customTitle) {
+            return
         }
+        this.title = title
+        this.titleChange.next(title)
     }
 
     /**

--- a/tabby-core/src/services/app.service.ts
+++ b/tabby-core/src/services/app.service.ts
@@ -238,7 +238,8 @@ export class AppService {
             this._activeTab?.emitFocused()
             this._activeTab?.emitVisibility(true)
         })
-        this.hostWindow.setTitle(this._activeTab?.title)
+        const active = this._activeTab
+        this.hostWindow.setTitle(active ? active.customTitle || active.title : undefined)
     }
 
     getParentTab (tab: BaseTabComponent): SplitTabComponent|null {
@@ -327,6 +328,7 @@ export class AppService {
         const modal = this.ngbModal.open(RenameTabModalComponent)
         modal.componentInstance.value = tab.customTitle || tab.title
         modal.result.then(result => {
+            tab.customTitle = ''
             tab.setTitle(result)
             tab.customTitle = result
             this.emitTabsChanged()


### PR DESCRIPTION
## Problem

After renaming tabs, switching between them restores the original host/session title in the OS window title bar. Tab headers keep the custom name; the window does not.

## Root cause

- Tab headers use `customTitle || title`.
- The window used only `title`.
- Dynamic titles (OSC / SSH) still called `setTitle()`, which overwrote `title` even when `customTitle` was set (it only suppressed `titleChange$`).

## Fix

- `setTitle`: no-op while `customTitle` is set so dynamic updates cannot clobber a rename.
- `renameTab`: clear `customTitle` briefly so `setTitle` can write `title` and emit `titleChange$` for the active tab.
- `selectTab`: set the window title from `customTitle || title`, matching tab headers.

Addresses #11489