### PR TITLE
Default value of host changed from null to empty string

### DIFF
--- a/tabby-core/src/services/vault.service.ts
+++ b/tabby-core/src/services/vault.service.ts
@@ -202,7 +202,7 @@ export class VaultService {
         let vaultSecret = vault.secrets.find(s => s.type === type && this.keyMatches(key, s))
         if (!vaultSecret) {
             // search for secret without host in vault (like a default user/password used in multiple servers)
-            key['host'] = null
+            key['host'] = ''
             vaultSecret = vault.secrets.find(s => s.type === type && this.keyMatches(key, s))
         }
         return vaultSecret ?? null


### PR DESCRIPTION
## Description

Due to recent updates, the default host param is now an empty string instead of null.
Resolves #11566
Related to #10076

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [x] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
