### PR TITLE
fix(ssh): parse X11 display specs without a screen number

### DIFF
--- a/tabby-ssh/src/session/x11.ts
+++ b/tabby-ssh/src/session/x11.ts
@@ -7,7 +7,7 @@ export class X11Socket {
 
     static resolveDisplaySpec (spec?: string|null): SocketConnectOpts {
         // eslint-disable-next-line prefer-const, @typescript-eslint/no-unused-vars
-        let [_, xHost, xDisplay] = /^(.+):(\d+)(?:.(\d+))$/.exec(spec ?? process.env.DISPLAY ?? 'localhost:0') ?? [undefined, undefined, undefined]
+        let [_, xHost, xDisplay] = /^(.+)?:(\d+)(?:\.(\d+))?$/.exec(spec ?? process.env.DISPLAY ?? 'localhost:0') ?? [undefined, undefined, undefined]
         if (process.platform === 'win32') {
             xHost ??= 'localhost'
         } else {


### PR DESCRIPTION
Addresses #11576

## Problem

`X11Socket.resolveDisplaySpec()` only accepted `host:display.screen`. Specs without a screen number (`localhost:1`, `192.168.1.5:0`, `$DISPLAY=:1`) failed the regex, discarded host and display, and silently connected to local display 0.

## Fix

Make the host and screen groups optional and escape the screen dot:

```
/^(.+)?:(\d+)(?:\.(\d+))?$/
```

Call sites are unchanged. Unix socket paths and `host:display.screen` still resolve the same way.

## Verification

Table against `resolveDisplaySpec` (linux / darwin / win32): 16/16 after the change. Before it, 7 of those cases failed (the ones without a screen number, plus `localhost:10X0` matching because `.` was unescaped).

`eslint` and `tsc --noEmit` on `x11.ts` are clean.

## Note

Linux/macOS `localhost:0` (no screen) now resolves to TCP `localhost:6000` instead of the unix socket. That is the X11 meaning of that spec. Bare `:0` and `$DISPLAY=:0` still use the unix socket.