### PR TITLE
fix(core): save tab recovery state before disabling it on close

### DIFF
--- a/tabby-core/src/services/app.service.ts
+++ b/tabby-core/src/services/app.service.ts
@@ -472,8 +472,8 @@ export class AppService {
     }
 
     async closeWindow (): Promise<void> {
-        this.tabRecovery.enabled = false
         await this.tabRecovery.saveTabs(this.tabs)
+        this.tabRecovery.enabled = false
         if (await this.closeAllTabs()) {
             this.hostWindow.close()
         } else {


### PR DESCRIPTION
Addresses #11593

## Problem

`AppService.closeWindow()` set `tabRecovery.enabled = false` and then called `saveTabs()`. `saveTabs()` returns immediately when that flag is off, so the snapshot that is supposed to run on a clean close never wrote. Recovery on the next launch was whatever the last 1s/30s debounce had stored.

`enabled = false` is still required *during* teardown: `closeAllTabs()` destroys tabs and that would otherwise save an empty list over the snapshot.

## Fix

Save first, then latch the flag off:

```ts
async closeWindow (): Promise<void> {
    await this.tabRecovery.saveTabs(this.tabs)
    this.tabRecovery.enabled = false
    if (await this.closeAllTabs()) {
        this.hostWindow.close()
    } else {
        this.tabRecovery.enabled = true
    }
}
```

`saveTabs()` is unchanged. If a tab blocks close, recovery is turned back on as before.

## Verification

Ran the real `saveTabs` / `closeWindow` bodies:

- save while enabled writes
- save while disabled is a no-op
- close writes current tab state, then disables
- a follow-up save of `[]` does not wipe that snapshot
- if a tab blocks close, recovery is re-enabled and the window stays open

`eslint` on `app.service.ts` is clean.