### PR TITLE
fix: do not hide docked window while a native dialog is open

### DIFF
--- a/app/lib/window.ts
+++ b/app/lib/window.ts
@@ -138,7 +138,8 @@ export class Window {
             if (
                 (this.configStore.appearance?.dock ?? 'off') !== 'off' &&
                 this.configStore.appearance?.dockHideOnBlur &&
-                !BrowserWindow.getFocusedWindow()
+                !BrowserWindow.getFocusedWindow() &&
+                this.window.isEnabled()
             ) {
                 this.hide()
             }


### PR DESCRIPTION
Addresses #11580

## Problem

With **Hide window on focus loss** on a docked window, pasting multiple lines opens Electron's native `showMessageBox`. That dialog is not a `BrowserWindow`, so `BrowserWindow.getFocusedWindow()` is `null`, hide-on-blur treats it as click-away, and the app hides under the still-open dialog. Restoring the window leaves input stuck on the missing dialog.

The same path is used for every other native message box, not only paste.

## Fix

Electron disables the parent window while that modal dialog is open. Do not hide in that case:

```ts
this.window.on('blur', () => {
    if (
        (this.configStore.appearance?.dock ?? 'off') !== 'off' &&
        this.configStore.appearance?.dockHideOnBlur &&
        !BrowserWindow.getFocusedWindow() &&
        this.window.isEnabled()
    ) {
        this.hide()
    }
})
```

Clicking another app still hides (the window stays enabled). Paste UI is unchanged.

## Verification

Ran the real blur-handler body:

- dock off → no hide
- hide-on-blur off → no hide
- another Tabby window focused → no hide
- click away, window enabled → hide
- native dialog, parent disabled → no hide