### PR TITLE
Fix Sogou IME commit when pressing Shift on Windows

### DIFF
--- a/tabby-terminal/src/frontends/xtermFrontend.ts
+++ b/tabby-terminal/src/frontends/xtermFrontend.ts
@@ -116,6 +116,23 @@ export class XTermFrontend extends Frontend {
         this.flowControl = new FlowControl(this.xterm)
         this.xtermCore = this.xterm['_core']
 
+        // xterm.js#6054 does this in _keyDown itself. Keep the workaround at
+        // that boundary so Shift cannot overwrite a previous keydown's state.
+        const oldKeyDown = this.xtermCore._keyDown.bind(this.xtermCore)
+        this.xtermCore._keyDown = (event: KeyboardEvent) => {
+            if (this.hostApp.platform !== Platform.Windows || event.key !== 'Shift' && event.keyCode !== 16) {
+                return oldKeyDown(event)
+            }
+
+            // Sogou can commit preedit text when Shift switches to English.
+            // Preserve the existing value so Shift itself does not arm
+            // xterm's input fallback guard.
+            const keyDownSeen = this.xtermCore._keyDownSeen
+            const result = oldKeyDown(event)
+            this.xtermCore._keyDownSeen = keyDownSeen
+            return result
+        }
+
         this.xterm.onBinary(data => {
             this.input.next(Buffer.from(data, 'binary'))
         })


### PR DESCRIPTION
## Description

Fixes dropped IME commit text on Windows when pressing <kbd>Shift</kbd> to switch Sogou Pinyin to English.

xterm.js sets its private `_keyDownSeen` fallback guard for every keydown. A pure Shift keydown can therefore suppress the following composed `input` event that carries the IME commit. This wraps xterm's `_keyDown` on Windows and restores the previous `_keyDownSeen` value for Shift-only keydowns, matching the upstream fix proposed in xtermjs/xterm.js#6054 until Tabby's xterm dependency includes it.

The check accepts both `event.key === 'Shift'` and legacy `keyCode === 16` event shapes.

### Testing

- `eslint tabby-terminal/src/frontends/xtermFrontend.ts`
- `tsc --noEmit --project tabby-terminal/tsconfig.json`
- Built the `tabby-terminal` plugin with Node.js 22 and packaged it into the official Tabby v1.0.235 Windows x64 portable binary.
- Manually verified on Windows with Sogou Pinyin: type preedit text, press Shift to switch to English, and confirm the preedit text is committed instead of being dropped.
- Verified normal PowerShell terminal startup and input in the patched build.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*